### PR TITLE
fix sitemap exclude paths

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -161,7 +161,7 @@ export default {
   sitemap: {
     hostname: 'https://debbie.codes',
     gzip: true,
-    exclude: ['code', '/code/**', 'test', 'thank-you']
+    exclude: ['/code', '/code/**', '/test', '/thank-you']
   },
 
   buildOptimisations: {


### PR DESCRIPTION
Without the `/` paths are not excluded from the sitemap.