### PR TITLE
fix: top navbar social alignment

### DIFF
--- a/components/TopBarSocial.vue
+++ b/components/TopBarSocial.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="flex gap-6 lg:gap-4 justify-center text-white mr-5 align-center">
+  <ul class="flex gap-6 lg:gap-4 justify-center text-white mr-5 items-center">
     <li>
       <a
         href="https://twitter.com/debs_obrien"


### PR DESCRIPTION
Hey! Just  a quick fix on your top navbar social

here the alignment error
<img width="214" alt="error" src="https://user-images.githubusercontent.com/11556276/208890027-1ed4ae27-60f1-40b0-b3e4-b0026c6dc45f.png">


Here the css class align-center should be items-center
<img width="520" alt="error2" src="https://user-images.githubusercontent.com/11556276/208890023-a9ebe35b-f330-49f6-82d4-202367d258d1.png">

Here the final result
<img width="238" alt="result" src="https://user-images.githubusercontent.com/11556276/208890014-3c0a7f85-6984-43ab-b0c1-0eed8d70b8aa.png">

Wanted to write a test. But sound a bit heavy to introduce visual regression or just checking the class ? Base on your current tests not sure its relevant I add more but tell me !

Have a good christmas debbie !
