### PR TITLE
fix: issue 418

### DIFF
--- a/components/TheTopBar.vue
+++ b/components/TheTopBar.vue
@@ -57,7 +57,7 @@ const toggle = () => {
     <!-- Dropdown -->
     <div
       v-show="isOpen"
-      class="text-white bg-dark w-full h-full px-10 mt-6 mb-6 text-center"
+      class="text-white bg-dark w-full h-full px-10 mt-6 mb-6 text-center lg:hidden"
       @click="isOpen = false"
     >
       <TheNavigation />


### PR DESCRIPTION
Just a quick fix that will close #418 

No JS so the menu will be open on re resize but it just hide the mobile dropdown menu base on your current breakpoints so here lg >

