### PR TITLE
Integrate MPT Service

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - main2
   pull_request:
     branches: [main]
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - main2
   pull_request:
     branches: [main]
 
@@ -12,15 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
+        shard: [1]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
     - name: Install dependencies
       run: npm ci
-    - name: Install Playwright browsers
-      run: npx playwright install --with-deps
+    #- name: Install Playwright browsers NO need to install browsers for service
+      #run: npx playwright install --with-deps
 
     - name: Run Playwright tests
       run: npx playwright test --shard ${{ matrix.shard }}
@@ -35,7 +36,7 @@ jobs:
 
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
-    if: always()
+    if: false # No need to merge 
     needs: [test]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1]
+        shard: [1] # Running all test in single run
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -24,7 +24,13 @@ jobs:
       #run: npx playwright install --with-deps
 
     - name: Run Playwright tests
-      run: npx playwright test --shard ${{ matrix.shard }}
+      working-directory: ./
+      env:
+        # Access token and regional endpoint for Microsoft Playwright Testing
+        PLAYWRIGHT_SERVICE_ACCESS_TOKEN: ${{ secrets.PLAYWRIGHT_SERVICE_ACCESS_TOKEN }}
+        PLAYWRIGHT_SERVICE_URL: ${{ secrets.PLAYWRIGHT_SERVICE_URL }}
+        PLAYWRIGHT_SERVICE_RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+      run: npx playwright test -c playwright.service.config.ts
 
     - name: Upload blob report to GitHub Actions Artifacts
       if: always()

--- a/playwright.service.config.ts
+++ b/playwright.service.config.ts
@@ -31,9 +31,9 @@ export default defineConfig(config, {
   // Define more generous timeout for the service operation if necessary.
   // timeout: 60000,
    expect: {
-     timeout: 10000,
+     timeout: 20000,
    },
-  workers: 20,
+  workers: 8,
 
   // Enable screenshot testing and configure directory with expectations.
   // https://learn.microsoft.com/azure/playwright-testing/how-to-configure-visual-comparisons

--- a/playwright.service.config.ts
+++ b/playwright.service.config.ts
@@ -30,9 +30,9 @@ const os = process.env.PLAYWRIGHT_SERVICE_OS || 'linux';
 export default defineConfig(config, {
   // Define more generous timeout for the service operation if necessary.
   // timeout: 60000,
-  // expect: {
-  //   timeout: 10000,
-  // },
+   expect: {
+     timeout: 10000,
+   },
   workers: 20,
 
   // Enable screenshot testing and configure directory with expectations.


### PR DESCRIPTION
- Use service config
- Increase action timeout
- limit worker to 8
- Disable sharding and merging
- Disable Install browser for service

PS: We could introduce service mode and using it we can maintain local vs service mode, else we could make two workflows.