### PR TITLE
chore: add DevSum 2026 talk redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -44,3 +44,4 @@
 /blog/all/5 /blog 301
 /blog/all/6 /blog 301
 /blog/all/7 /blog 301
+/talks/devsum-2026 https://github.com/debs-obrien/decks/tree/main/devsum-2026-agentic-developer-mcps 302

--- a/public/_redirects
+++ b/public/_redirects
@@ -44,4 +44,4 @@
 /blog/all/5 /blog 301
 /blog/all/6 /blog 301
 /blog/all/7 /blog 301
-/talks/devsum-2026 https://github.com/debs-obrien/decks/tree/main/devsum-2026-agentic-developer-mcps 302
+/talks/devsum-2026 https://github.com/debs-obrien/decks/tree/main/devsum-2026-agentic-developer-mcps 301


### PR DESCRIPTION
Adds /talks/devsum-2026 redirect to the public DevSum slide deck at debs-obrien/decks.