### PR TITLE
Memoize blog list reading times per post

### DIFF
--- a/components/BlogPostList.vue
+++ b/components/BlogPostList.vue
@@ -2,7 +2,7 @@
 import type { BlogPostPreview } from '~/types'
 import { calculateReadingTime, extractTextFromContent, formatReadingTime } from '~/utils/reading-time'
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   list: Array<BlogPostPreview>
   /** Render the first post as a larger lead card */
   lead?: boolean
@@ -10,7 +10,7 @@ withDefaults(defineProps<{
   lead: false,
 })
 
-function readingTimeLabel(item: BlogPostPreview) {
+function readingTimeForItem(item: BlogPostPreview): string | null {
   const text = extractTextFromContent((item as any).body)
     || extractTextFromContent((item as any).content)
     || item.description
@@ -20,8 +20,16 @@ function readingTimeLabel(item: BlogPostPreview) {
   return formatReadingTime(calculateReadingTime(text))
 }
 
-function isLead(index: number, lead?: boolean) {
-  return Boolean(lead && index === 0)
+/** Precompute once per list so template lookups are O(1). */
+const readingTimeByPath = computed(() => {
+  const labels = new Map<string, string | null>()
+  for (const item of props.list)
+    labels.set(item.path, readingTimeForItem(item))
+  return labels
+})
+
+function isLead(index: number) {
+  return Boolean(props.lead && index === 0)
 }
 </script>
 
@@ -31,7 +39,7 @@ function isLead(index: number, lead?: boolean) {
       v-for="(item, index) of list"
       :key="item.path"
       class="group rounded-xl bg-white dark:bg-slate-800/80 transition-colors duration-200 hover:bg-gray-50 dark:hover:bg-slate-700/50"
-      :class="isLead(index, lead) ? 'p-8' : 'p-6'"
+      :class="isLead(index) ? 'p-8' : 'p-6'"
     >
       <NuxtLink
         :to="item.path"
@@ -39,11 +47,11 @@ function isLead(index: number, lead?: boolean) {
       >
         <h3
           class="inline-flex items-center gap-3 font-bold text-gray-800 dark:text-white leading-tight group-hover:text-primary transition-colors"
-          :class="isLead(index, lead) ? 'text-2xl sm:text-3xl mb-3' : 'text-xl mb-2'"
+          :class="isLead(index) ? 'text-2xl sm:text-3xl mb-3' : 'text-xl mb-2'"
         >
           <svg
             class="text-primary transition-all duration-300 opacity-0 -translate-x-4 group-hover:opacity-100 group-hover:translate-x-0"
-            :class="isLead(index, lead) ? 'w-6 h-6' : 'w-5 h-5'"
+            :class="isLead(index) ? 'w-6 h-6' : 'w-5 h-5'"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -56,7 +64,7 @@ function isLead(index: number, lead?: boolean) {
         </h3>
         <p
           class="text-gray-600 dark:text-gray-400"
-          :class="isLead(index, lead) ? 'mb-4 text-base' : 'mb-3 text-sm'"
+          :class="isLead(index) ? 'mb-4 text-base' : 'mb-3 text-sm'"
         >
           {{ item.description }}
         </p>
@@ -64,8 +72,8 @@ function isLead(index: number, lead?: boolean) {
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="flex flex-wrap items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
           <Date :date="item.date" />
-          <span v-if="readingTimeLabel(item)">
-            {{ readingTimeLabel(item) }}
+          <span v-if="readingTimeByPath.get(item.path)">
+            {{ readingTimeByPath.get(item.path) }}
           </span>
         </div>
         <TagsList :tags="item.tags" section="blog" />

--- a/components/BlogPostList.vue
+++ b/components/BlogPostList.vue
@@ -23,8 +23,11 @@ function readingTimeForItem(item: BlogPostPreview): string | null {
 /** Precompute once per list so template lookups are O(1). */
 const readingTimeByPath = computed(() => {
   const labels = new Map<string, string | null>()
-  for (const item of props.list)
+  for (const item of props.list) {
+    if (!item.path)
+      continue
     labels.set(item.path, readingTimeForItem(item))
+  }
   return labels
 })
 


### PR DESCRIPTION
## Summary
- Precompute reading-time labels once per blog list into a path → label map
- Avoid running AST extraction and word counting twice per card on each render

## Test plan
- [ ] Blog index still shows reading times on cards
- [ ] Tag/year/archive blog lists still show reading times
- [ ] No console errors when browsing blog lists


Made with [Cursor](https://cursor.com)