### PR TITLE
fix: allow theaiplatform.app in Netlify Image CDN

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
     X-XSS-Protection = "1; mode=block"
 
 [images]
-  remote_images = ["res.cloudinary.com", "dev-to-uploads.s3.amazonaws.com", "raw.githubusercontent.com"]
+  remote_images = ["res.cloudinary.com", "dev-to-uploads.s3.amazonaws.com", "raw.githubusercontent.com", "theaiplatform.app"]
 
 [build.environment]
   NODE_VERSION = "22.12.0"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
         },
       },
     },
-    domains: ['res.cloudinary.com', 'images.unsplash.com', 'dev-to-uploads.s3.amazonaws.com', 'raw.githubusercontent.com'],
+    domains: ['res.cloudinary.com', 'images.unsplash.com', 'dev-to-uploads.s3.amazonaws.com', 'raw.githubusercontent.com', 'theaiplatform.app'],
     format: ['webp'],
     quality: 80,
     screens: {


### PR DESCRIPTION
## Summary
- Closes #578
- Allowlists `theaiplatform.app` in Netlify `[images].remote_images` so `/.netlify/images` no longer returns 400 for those URLs
- Adds the same host to Nuxt Image `domains` so optimized images stay consistent in config

Backfilled from local skill test: candidate → issue #578 → draft PR.

Reproduced on prod: https://debbie.codes/blog/an-agent-that-hunts-bugs-while-i-sleep/

## Test plan
- [x] Deploy preview CDN returns 200 for `theaiplatform.app` image URLs (verified)
- [ ] After merge: prod blog post inline `loop-diagram.png` / `bug-after.png` load
- [ ] Spot-check an existing Cloudinary or GitHub-hosted image still loads