### PR TITLE
Tighten videos grid on wide screens

### DIFF
--- a/components/VideoList.vue
+++ b/components/VideoList.vue
@@ -9,6 +9,7 @@ defineProps<{
 <template>
   <ul
     class="mt-12 grid gap-8 grid-cols-1 sm:grid-cols-2"
+    :class="list.length > 2 ? 'lg:grid-cols-3 xl:grid-cols-4' : ''"
   >
     <li v-for="video of list" :key="video.video" data-test-id="interviews">
       <VideoCard :item="video" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
On wide viewports, the All Videos grid was capped at 2 columns (`grid-cols-1 sm:grid-cols-2` in `VideoList.vue`), so cards stretched huge and only two videos showed above the fold.

This PR aligns the videos grid with the existing `PodcastGrid` breakpoints:
- mobile: 1 column
- `sm` (tablet): 2 columns
- `lg`: 3 columns
- `xl`: 4 columns (when there are more than 2 videos)

No content schema changes and no card restyle — density only.

## Before / After

**Before (live, 1440px):** 2 oversized cards dominate the row.

![Before: videos grid at 1440px with 2 large cards](https://cursor.com/artifacts/c/art-f6950b9d-a68f-4c54-bc53-6692a0dac947)

**After (local, 1440px):** 4 columns — more videos visible, cards no longer blow up.

![After: videos grid at 1440px with 4 denser cards](https://cursor.com/artifacts/c/art-c34f737c-3545-4cd2-a9bb-7da0ae9d0ac9)

**After (local, 1024px / lg):** 3 columns.

![After: videos grid at 1024px with 3 columns](https://cursor.com/artifacts/c/art-e226884c-98b4-426e-a1ad-1cc974119af4)

**After (local, 768px / tablet):** still 2 columns.

![After: videos grid at 768px with 2 columns](https://cursor.com/artifacts/c/art-e4c27466-1a5f-48b8-89fb-84c151d6c566)

**After (local, 390px / mobile):** still 1 column.

![After: videos grid at 390px with 1 column](https://cursor.com/artifacts/c/art-89d634a0-694e-4987-876f-b764241b1dc5)

## Change
```diff
// components/VideoList.vue
- class="mt-12 grid gap-8 grid-cols-1 sm:grid-cols-2"
+ class="mt-12 grid gap-8 grid-cols-1 sm:grid-cols-2"
+ :class="list.length > 2 ? 'lg:grid-cols-3 xl:grid-cols-4' : ''"
```

## Test plan
- [ ] Open `/videos` at ~1280px+ width — expect 4 columns on `xl`
- [ ] Check ~1024px — expect 3 columns on `lg`
- [ ] Check tablet (~640–1023px) — still 2 columns
- [ ] Check mobile — still 1 column
- [ ] Tag filter pages (`/videos/tags/...`) and `/videos/all` use the same `VideoList` component
- [ ] Cards still match existing thumbnail/hover/typography look

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8caa10d1-ccff-455d-9edd-6f63002baff7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8caa10d1-ccff-455d-9edd-6f63002baff7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

