### PR TITLE
Fix YouTube embeds on blog posts

### DIFF
--- a/components/content/LiteYoutube.vue
+++ b/components/content/LiteYoutube.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+/**
+ * Nuxt Content turns <lite-youtube> in markdown into a LiteYoutube Vue
+ * component. This wrapper mounts the real lite-youtube-embed custom element
+ * (registered by plugins/youtube.client.js).
+ */
+withDefaults(defineProps<{
+  videoid: string
+  playlabel?: string
+  start?: string | number
+}>(), {
+  playlabel: 'Play video',
+  start: 0,
+})
+</script>
+
+<template>
+  <ClientOnly>
+    <lite-youtube
+      :videoid="videoid"
+      :playlabel="playlabel"
+      :start="start"
+    />
+  </ClientOnly>
+</template>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the live site (no login), blog posts that use `<lite-youtube>` in markdown emit an unknown HTML element with the hyphen stripped:

```html
<liteyoutube videoid="xDNLKLg7Ib8" playlabel="..."></liteyoutube>
```

Custom elements need a hyphen, so the browser collapses that to nothing. Zero iframes, no thumbnail, no player.

Same on both:
- `/blog/i-tested-if-grok-bot-could-book-my-flights` (`xDNLKLg7Ib8`)
- `/blog/grok-bot-just-dropped` (`kiDvQnoCveU`)

Markdown still has `<lite-youtube videoid="...">`. Content keeps the tag in the AST as `lite-youtube`, but without a matching Vue component Vue renders `LiteYoutube`, which HTML lowercases to `liteyoutube`.

## Fix

Register `components/content/LiteYoutube.vue`. Nuxt Content already lists it in local content components. The wrapper mounts the real `lite-youtube-embed` custom element (CSS + `plugins/youtube.client.js` already in the repo). Blog markdown is unchanged.

## Verification

Production preview (`npm run build` + `node .output/server/index.mjs`):

- No `<liteyoutube>` unknown tag
- Real `<lite-youtube>` with ytimg thumbnail + play button
- Click loads `youtube-nocookie.com` iframe for both posts

![Flights post with lite-youtube facade](https://cursor.com/artifacts/c/art-8aca974b-0456-45ce-b513-102f19533680)
![After play click](https://cursor.com/artifacts/c/art-6a41a6d7-8bfc-4741-a9c3-380d91f56142)

## Test plan

- [ ] Open `/blog/i-tested-if-grok-bot-could-book-my-flights` and confirm the YouTube facade for `xDNLKLg7Ib8`
- [ ] Confirm play starts the video
- [ ] Spot-check `/blog/grok-bot-just-dropped` (`kiDvQnoCveU`)
- [ ] Confirm no bare `<liteyoutube>` in page HTML
- [ ] Confirm `/videos` cards still work (unchanged)

Do not merge until Debbie signs off.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fd95bbe-80a8-422c-b85a-b893f201b41b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fd95bbe-80a8-422c-b85a-b893f201b41b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

