### PR TITLE
Fix wording on gluten-free beer video blurb

### DIFF
--- a/content/videos/i-sent-grok-bot-to-buy-my-gluten-free-beer.md
+++ b/content/videos/i-sent-grok-bot-to-buy-my-gluten-free-beer.md
@@ -1,7 +1,7 @@
 ---
 title: "I sent Grok Bot to buy my gluten-free beer"
 date: 2026-08-16
-description: "I ran out of gluten-free beer and asked my chief of staff to buy more. Amazon from my phone, Alcampo would not let me log in, a morning podcast, and a delivery slot I can keep adding to."
+description: "I ran out of gluten-free beer and asked my Grok Bot chief of staff to buy more. Amazon jumbo rolls from my phone, Alcampo wouldn't let me log in, a morning podcast, and a delivery slot I can keep adding to."
 video: 6v9txfFIwtw
 tags: [ai]
 host: Debbie O'Brien

--- a/content/videos/i-sent-grok-bot-to-buy-my-gluten-free-beer.md
+++ b/content/videos/i-sent-grok-bot-to-buy-my-gluten-free-beer.md
@@ -1,7 +1,7 @@
 ---
 title: "I sent Grok Bot to buy my gluten-free beer"
 date: 2026-08-16
-description: "I ran out of gluten-free beer and asked my Grok Bot chief of staff to buy more. Amazon jumbo rolls from my phone, Alcampo login hell, a morning podcast, and a delivery slot I can keep adding to."
+description: "I ran out of gluten-free beer and asked my chief of staff to buy more. Amazon from my phone, Alcampo would not let me log in, a morning podcast, and a delivery slot I can keep adding to."
 video: 6v9txfFIwtw
 tags: [ai]
 host: Debbie O'Brien


### PR DESCRIPTION
Drops "Alcampo login hell" from the videos-page description. Videos entry only. Does not touch blog PR 586.