### PR TITLE
fix: remove YouTube thumbnail 404s causing console errors on /videos

### DIFF
--- a/components/FeaturedVideoSection.vue
+++ b/components/FeaturedVideoSection.vue
@@ -5,7 +5,6 @@ const props = defineProps<{
   list: Array<VideoPreview>
 }>()
 
-const getYouTubeThumbnail = (videoId: string) => `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
 const getYouTubeUrl = (videoId: string) => `https://www.youtube.com/watch?v=${videoId}`
 
 const mainVideo = computed(() => props.list[0])
@@ -19,7 +18,7 @@ const otherVideos = computed(() => props.list.slice(1))
       <NuxtLink :to="getYouTubeUrl(mainVideo.video)" target="_blank" rel="noopener noreferrer">
         <div class="aspect-video rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
           <img
-            :src="getYouTubeThumbnail(mainVideo.video)"
+            :src="youtubeThumbnail(mainVideo.video)"
             :alt="mainVideo.title"
             class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
           >
@@ -43,7 +42,7 @@ const otherVideos = computed(() => props.list.slice(1))
         <NuxtLink :to="getYouTubeUrl(video.video)" target="_blank" rel="noopener noreferrer" class="flex items-start gap-4">
           <div class="flex-shrink-0">
             <img
-              :src="getYouTubeThumbnail(video.video)"
+              :src="youtubeThumbnail(video.video)"
               :alt="video.title"
               width="128"
               height="72"

--- a/components/VideoCard.vue
+++ b/components/VideoCard.vue
@@ -15,6 +15,7 @@ defineProps<{
         :videoid="item.video"
         :playlabel="item.title"
         :start="item.start ? item.start : 0"
+        :style="youtubePosterStyle(item.video)"
       />
 
       <div class="p-6">

--- a/components/content/LiteYoutube.vue
+++ b/components/content/LiteYoutube.vue
@@ -20,6 +20,7 @@ withDefaults(defineProps<{
       :videoid="videoid"
       :playlabel="playlabel"
       :start="start"
+      :style="youtubePosterStyle(videoid)"
     />
   </ClientOnly>
 </template>

--- a/content/videos/whats-new-in-sofware-advocacy.md
+++ b/content/videos/whats-new-in-sofware-advocacy.md
@@ -1,8 +1,0 @@
----
-title: What's Next in Software Advocacy?
-date: 2021-01-07
-description: Super fun talk with Debbie O’Brien, Head of Learning and Developer Advocate at NuxtJS, about the current development in her sector, the Github Star, and her idea of Tech for Good.
-video: Ul00M-j9XaU
-tags: [interviews, nuxt]
-host: Fabian Böck
----

--- a/content/videos/women-in-tech-panel.md
+++ b/content/videos/women-in-tech-panel.md
@@ -1,8 +1,0 @@
----
-title: Managing Component Architecture
-date: 2021-03-25
-description: In this episode, Tracy Lee interviews Debbie O'Brien about [bit.dev](https://bit.dev), a new open source tool for helping developer share components. We learn how to use Bit to manage component architecture, think in components, and how this can help you a build more scalable, reusable codebase and work across teams.
-video: pOZas9RPJcY
-tags: [interviews, architecture]
-host: Tracy Lee
----

--- a/utils/youtube.ts
+++ b/utils/youtube.ts
@@ -4,7 +4,8 @@
  * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
  */
 export function youtubeThumbnail(videoId: string) {
-  return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
+  const safeId = encodeURIComponent(videoId.trim())
+  return `https://i.ytimg.com/vi/${safeId}/hqdefault.jpg`
 }
 
 /**

--- a/utils/youtube.ts
+++ b/utils/youtube.ts
@@ -1,0 +1,24 @@
+/**
+ * `hqdefault.jpg` is the only thumbnail variant YouTube generates for every upload,
+ * so it is the safe choice for a poster image.
+ * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
+ */
+export function youtubeThumbnail(videoId: string) {
+  return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
+}
+
+/**
+ * Inline background image for <lite-youtube>.
+ *
+ * lite-youtube-embed only paints its own poster when the element has no inline
+ * background-image, and it follows that with a speculative request for
+ * `vi_webp/<id>/sddefault.webp`. YouTube has no sddefault.webp for older 4:3
+ * uploads, so those requests 404, Chrome logs each one as a console error and
+ * Lighthouse's errors-in-console audit fails on /videos/.
+ *
+ * Setting the poster ourselves skips both: no 404s, no extra request per embed,
+ * and the poster is in the server-rendered HTML instead of waiting on JS.
+ */
+export function youtubePosterStyle(videoId: string) {
+  return { backgroundImage: `url("${youtubeThumbnail(videoId)}")` }
+}


### PR DESCRIPTION
Follow-up to the baseline Lighthouse audit of the site. The `errors-in-console` best-practices audit fails on [/videos/](https://debbie.codes/videos/) with six 404s on `i.ytimg.com`. Home and blog pages pass, so there is no global script error, contrary to the original hypothesis.

Two separate causes.

### 1. Two dead YouTube videos

| Entry | Video ID | Status |
|---|---|---|
| `content/videos/whats-new-in-sofware-advocacy.md` | `Ul00M-j9XaU` | [oEmbed 404](https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=Ul00M-j9XaU&format=json) — deleted |
| `content/videos/women-in-tech-panel.md` | `pOZas9RPJcY` | oEmbed 403 — private or removed |

Every thumbnail variant 404s for both, so those two cards rendered with no poster and linked to an unavailable video. That is a user-facing break, not just a console entry, so the entries are removed. If either talk gets re-uploaded, adding the file back with the new ID is a one-liner.

### 2. `lite-youtube-embed`'s speculative poster upgrade

`connectedCallback` paints `i.ytimg.com/vi/<id>/hqdefault.jpg` and then calls `upgradePosterImage()`, which requests `i.ytimg.com/vi_webp/<id>/sddefault.webp` ([source](https://unpkg.com/lite-youtube-embed@0.3.3/src/lite-yt-embed.js)). YouTube does not generate `sddefault.webp` for older 4:3 uploads, so it 404s for `CEXoGajxY60` and `Be3N_i4bC34`. Visually harmless, since the jpg poster is already in place, but Chrome logs every 404 as a console error and Lighthouse counts it. See [youtube-thumbnail-urls.md](https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md).

Both the poster paint and the upgrade are guarded by `if (!this.style.backgroundImage)`, so setting the poster inline ourselves skips both. That is what `utils/youtube.ts` does, and `VideoCard` and the `LiteYoutube` content component now use it.

### Scope check

All 137 video IDs in `content/videos` and `content/blog` were checked against `i.ytimg.com`: 2 dead, 2 more missing `sddefault.webp`. `/videos/` renders every card on one page, which is why it was the only route hitting all four.

### Verified locally

- `/videos`: 264 `i.ytimg.com` requests with 6 404s, down to 132 with zero 404s. The `sddefault.webp` upgrade accounted for half the requests on the page.
- `errors-in-console` scores 1 on the local `/videos` build.
- Posters still render on `/videos`, on the grok blog post embed, and in the home featured section.
- `eslint` clean on all changed files.

### Not in this PR

`/videos/` renders all 132 embeds with no pagination or lazy loading, which is worth a separate look alongside the blog Speed Index finding.
