### PR TITLE
Remove Zephyr as current employer from site surface copy

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <script setup>
-const description = 'Debbie O\'Brien, Platform Engineer – Applied AI at Zephyr Cloud, with over 15 years experience in Frontend development. Google Developer Expert in web technologies, Previous Microsoft Most Valuable Professional in developer technologies, GitHub Star Alumni, Nuxt Ambassador and Cloudinary Media Developer Expert.'
+const description = 'Debbie O\'Brien, Developer Educator focused on Playwright, testing & AI agents, with over 15 years experience in Frontend development. Google Developer Expert in web technologies, Previous Microsoft Most Valuable Professional in developer technologies, GitHub Star Alumni, Nuxt Ambassador and Cloudinary Media Developer Expert.'
 const ogTitle = 'Debbie codes and helps others learn Playwright, testing, React, Nuxt and more'
 const twitterDescription = 'My website of where I play around with Nuxt, Playwright and more and showcase my blog, resources etc'
 const twitterCard = 'https://debbie.codes/twitter-card.png'

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <script setup>
-const description = 'Debbie O\'Brien, Developer Educator focused on Playwright, testing & AI agents, with over 15 years experience in Frontend development. Google Developer Expert in web technologies, Previous Microsoft Most Valuable Professional in developer technologies, GitHub Star Alumni, Nuxt Ambassador and Cloudinary Media Developer Expert.'
+const description = 'Debbie O\'Brien, Developer Educator focused on Playwright, testing & AI agents, with over 15 years experience in Frontend development. Google Developer Expert in web technologies, Former Microsoft Most Valuable Professional in developer technologies, GitHub Star Alumni, Nuxt Ambassador and Cloudinary Media Developer Expert.'
 const ogTitle = 'Debbie codes and helps others learn Playwright, testing, React, Nuxt and more'
 const twitterDescription = 'My website of where I play around with Nuxt, Playwright and more and showcase my blog, resources etc'
 const twitterCard = 'https://debbie.codes/twitter-card.png'

--- a/components/CreativeHero.vue
+++ b/components/CreativeHero.vue
@@ -17,7 +17,7 @@
       <div class="hero-animate hero-animate-2 hero-rule mt-5" aria-hidden="true" />
 
       <p class="hero-animate hero-animate-2 mt-4 text-lg md:text-xl text-gray-300 max-w-2xl">
-        Platform Engineer – Applied AI at Zephyr Cloud
+        Developer Educator focused on Playwright, testing & AI agents
       </p>
 
       <div class="hero-animate hero-animate-3 mt-6 flex flex-wrap justify-center items-center gap-2.5">

--- a/content/about.md
+++ b/content/about.md
@@ -4,7 +4,7 @@ title: About
 
 With over 15 years experience in Frontend development, I have worked as a Tech Lead and consultant for many clients across a range of technologies, often with a strong focus on performance. I have led teams both in house and remotely, and delivered workshops and training along the way. I have mentored learners on Treehouse and OpenClassrooms, teach at [Vue School](https://vueschool.io/courses/internationalization-with-vue-i18n) and [Jamstack Explorers](https://explorers.netlify.com/learn/get-started-with-nuxt), and write for [Ultimate Courses](https://ultimatecourses.com/author/debbieobrien).
 
-I am a Platform Engineer – Applied AI at Zephyr Cloud, a Google Developer Expert in web technologies, and a Nuxt Ambassador — previously Developer Relations at Nuxt. I am also a former Microsoft Most Valuable Professional in developer technologies, Cloudinary Media Developer Expert, and GitHub Star Alumni.
+I am a Developer Educator focused on Playwright, testing and AI agents, a Google Developer Expert in web technologies, and a Nuxt Ambassador. I previously worked in Developer Relations at Nuxt and as a Platform Engineer for Applied AI at Zephyr Cloud. I am also a former Microsoft Most Valuable Professional in developer technologies, Cloudinary Media Developer Expert, and GitHub Star Alumni.
 
 I have a special love for JavaScript frameworks, especially Vue.js and Nuxt.js, and spend a lot of my time on testing — particularly end-to-end testing with Playwright and how AI fits into modern developer workflows. I hold Frontend and Full Stack tech degrees and am Microsoft certified. I speak internationally at meetups and conferences around the world, including Antarctica.
 

--- a/content/about.md
+++ b/content/about.md
@@ -4,7 +4,7 @@ title: About
 
 With over 15 years experience in Frontend development, I have worked as a Tech Lead and consultant for many clients across a range of technologies, often with a strong focus on performance. I have led teams both in house and remotely, and delivered workshops and training along the way. I have mentored learners on Treehouse and OpenClassrooms, teach at [Vue School](https://vueschool.io/courses/internationalization-with-vue-i18n) and [Jamstack Explorers](https://explorers.netlify.com/learn/get-started-with-nuxt), and write for [Ultimate Courses](https://ultimatecourses.com/author/debbieobrien).
 
-I am a Developer Educator focused on Playwright, testing and AI agents, a Google Developer Expert in web technologies, and a Nuxt Ambassador. I previously worked in Developer Relations at Nuxt and as a Platform Engineer for Applied AI at Zephyr Cloud. I am also a former Microsoft Most Valuable Professional in developer technologies, Cloudinary Media Developer Expert, and GitHub Star Alumni.
+I teach people how to test and ship with AI. I was a Principal Technical Program Manager at Microsoft focused on Playwright — developer education, docs, and helping teams adopt end-to-end testing at scale. I am a Google Developer Expert in web technologies, and a former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star.
 
 I have a special love for JavaScript frameworks, especially Vue.js and Nuxt.js, and spend a lot of my time on testing — particularly end-to-end testing with Playwright and how AI fits into modern developer workflows. I hold Frontend and Full Stack tech degrees and am Microsoft certified. I speak internationally at meetups and conferences around the world, including Antarctica.
 

--- a/content/about.md
+++ b/content/about.md
@@ -4,7 +4,7 @@ title: About
 
 With over 15 years experience in Frontend development, I have worked as a Tech Lead and consultant for many clients across a range of technologies, often with a strong focus on performance. I have led teams both in house and remotely, and delivered workshops and training along the way. I have mentored learners on Treehouse and OpenClassrooms, teach at [Vue School](https://vueschool.io/courses/internationalization-with-vue-i18n) and [Jamstack Explorers](https://explorers.netlify.com/learn/get-started-with-nuxt), and write for [Ultimate Courses](https://ultimatecourses.com/author/debbieobrien).
 
-I teach people how to test and ship with AI. I was a Principal Technical Program Manager at Microsoft focused on Playwright — developer education, docs, and helping teams adopt end-to-end testing at scale. I am a Google Developer Expert in web technologies, and a former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star.
+I help people work with AI agents. I build and use multi-agent workflows every day. I was a Principal Technical Program Manager at Microsoft, focused on Playwright. I am a Google Developer Expert in web technologies, and a former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star.
 
 I have a special love for JavaScript frameworks, especially Vue.js and Nuxt.js, and spend a lot of my time on testing — particularly end-to-end testing with Playwright and how AI fits into modern developer workflows. I hold Frontend and Full Stack tech degrees and am Microsoft certified. I speak internationally at meetups and conferences around the world, including Antarctica.
 

--- a/content/podcasts/dotnet-rocks-ai-testing.md
+++ b/content/podcasts/dotnet-rocks-ai-testing.md
@@ -1,7 +1,7 @@
 ---
 title: The Role of AI in Testing with Debbie O'Brien
 date: 2026-07-16
-description: How has testing changed in the era of AI? Carl and Richard talk to Debbie O'Brien in her new role at Zephyr about using LLMs to help build and validate tests - and much more. Debbie talks about joining Zephyr and using testing tools like Playwright to validate application workflows and generate documentation. This leads to a discussion about documentation being more important than ever, since LLMs will actually read it! Maintaining quality is a challenge with LLM-generated code and tests, so there's always a role for a critical eye in the process.
+description: How has testing changed in the era of AI? Carl and Richard talk to Debbie O'Brien about using LLMs to help build and validate tests, drawing on her work at Zephyr Cloud. Debbie talks about using Playwright to validate application workflows and generate documentation. This leads to a discussion about documentation being more important than ever, since LLMs will actually read it! Maintaining quality is a challenge with LLM-generated code and tests, so there's always a role for a critical eye in the process.
 image: https://res.cloudinary.com/debsobrien/image/upload/c_thumb,w_200/v1633724388/debbie.codes/podcasts/dotnet-rocks_ui02cg
 url: https://www.dotnetrocks.com/details/2011
 tags: [testing, playwright]

--- a/server/routes/feed.xml.ts
+++ b/server/routes/feed.xml.ts
@@ -11,7 +11,7 @@ export default defineEventHandler(async (event) => {
 
   const feed = new Feed({
     title: 'Debbie Codes',
-    description: 'Debbie O\'Brien - Platform Engineer – Applied AI at Zephyr Cloud, with over 15 years experience in Frontend development. Writing about Playwright, testing, React, Nuxt and more.',
+    description: 'Debbie O\'Brien - Developer Educator focused on Playwright, testing & AI agents, with over 15 years experience in Frontend development. Writing about Playwright, testing, React, Nuxt and more.',
     id: siteUrl,
     link: siteUrl,
     language: 'en',

--- a/specs/test-plan.md
+++ b/specs/test-plan.md
@@ -2,7 +2,7 @@
 
 ## Application Overview
 
-**Debbie.Codes** is a Nuxt 3-based personal portfolio and content website for Debbie O'Brien, a Platform Engineer – Applied AI at Zephyr Cloud. The site serves as a central hub for her professional content, including blog posts, videos, podcasts, courses, and biographical information.
+**Debbie.Codes** is a Nuxt 3-based personal portfolio and content website for Debbie O'Brien, a Developer Educator focused on Playwright, testing & AI agents. The site serves as a central hub for her professional content, including blog posts, videos, podcasts, courses, and biographical information.
 
 ### Key Features
 - **Content Management**: Markdown-driven content using Nuxt Content v2
@@ -31,7 +31,7 @@
 
 **Expected Results:**
 - Heading "Debbie O'Brien" is displayed with level 1
-- Subtitle "Platform Engineer – Applied AI at Zephyr Cloud" is visible
+- Subtitle "Developer Educator focused on Playwright, testing & AI agents" is visible
 - Page title includes "Debbie codes and helps others learn Playwright, testing, React, Nuxt and more"
 
 #### 1.2 Verify Award Badges Display

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -27,12 +27,11 @@ test.describe('About Page', () => {
     });
 
     await test.step('Verify role and achievements', async () => {
-      await expect(page.locator('.prose').getByText(/Developer Educator focused on Playwright, testing and AI agents/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/previously worked in Developer Relations at Nuxt/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/Platform Engineer for Applied AI at Zephyr Cloud/)).toBeVisible();
       // Bio + awards section both mention GDE — scope to the bio content renderer
+      await expect(page.locator('.prose').getByText(/I teach people how to test and ship with AI/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/Principal Technical Program Manager at Microsoft focused on Playwright/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Google Developer Expert in web technologies/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/Nuxt Ambassador/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star/)).toBeVisible();
     });
 
   });

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -28,8 +28,9 @@ test.describe('About Page', () => {
 
     await test.step('Verify role and achievements', async () => {
       // Bio + awards section both mention GDE — scope to the bio content renderer
-      await expect(page.locator('.prose').getByText(/I teach people how to test and ship with AI/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/Principal Technical Program Manager at Microsoft focused on Playwright/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/I help people work with AI agents/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/I build and use multi-agent workflows every day/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/Principal Technical Program Manager at Microsoft, focused on Playwright/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Google Developer Expert in web technologies/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star/)).toBeVisible();
     });

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -26,12 +26,13 @@ test.describe('About Page', () => {
       await expect(bioParagraph).toContainText('Jamstack Explorers');
     });
 
-    await test.step('Verify current role and achievements', async () => {
-      await expect(page.getByText('Platform Engineer – Applied AI at Zephyr Cloud')).toBeVisible();
+    await test.step('Verify role and achievements', async () => {
+      await expect(page.locator('.prose').getByText(/Developer Educator focused on Playwright, testing and AI agents/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/previously worked in Developer Relations at Nuxt/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/Platform Engineer for Applied AI at Zephyr Cloud/)).toBeVisible();
       // Bio + awards section both mention GDE — scope to the bio content renderer
       await expect(page.locator('.prose').getByText(/Google Developer Expert in web technologies/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Nuxt Ambassador/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/previously Developer Relations at Nuxt/)).toBeVisible();
     });
 
   });

--- a/tests/home-featured-content.spec.ts
+++ b/tests/home-featured-content.spec.ts
@@ -7,7 +7,7 @@ test.describe('Home Page Featured Content', () => {
 
   test('displays main hero section with correct information', async ({ page }) => {
     await expect(page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })).toBeVisible();
-    await expect(page.getByText('Platform Engineer – Applied AI at Zephyr Cloud')).toBeVisible();
+    await expect(page.getByText('Developer Educator focused on Playwright, testing & AI agents')).toBeVisible();
 
     // Profile image in the top bar
     const profileImage = page.getByRole('img', { name: 'Debbie O\'Brien' }).first();
@@ -119,7 +119,7 @@ test.describe('Home Page Featured Content', () => {
 
   test('home page content is accessible', async ({ page }) => {
     await expect(page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })).toBeVisible();
-    await expect(page.getByText('Platform Engineer – Applied AI at Zephyr Cloud')).toBeVisible();
+    await expect(page.getByText('Developer Educator focused on Playwright, testing & AI agents')).toBeVisible();
 
     const h2s = page.getByRole('heading', { level: 2 });
     const h2Count = await h2s.count();

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
 
 test('home contains name and title', async ({ page }) => {
   await expect(page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })).toBeVisible();
-  await expect(page.getByText('Platform Engineer – Applied AI at Zephyr Cloud')).toBeVisible();
+  await expect(page.getByText('Developer Educator focused on Playwright, testing & AI agents')).toBeVisible();
 });
 
 // Featured Posts section no longer exists after redesign

--- a/tests/verify-home-page-header-and-introduction.spec.ts
+++ b/tests/verify-home-page-header-and-introduction.spec.ts
@@ -8,7 +8,7 @@ test.describe('Home Page Content Display', { tag: '@agent' }, () => {
     await page.goto('/');
 
     await expect(page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })).toBeVisible();
-    await expect(page.getByText('Platform Engineer – Applied AI at Zephyr Cloud')).toBeVisible();
+    await expect(page.getByText('Developer Educator focused on Playwright, testing & AI agents')).toBeVisible();
 
     await expect(page).toHaveTitle(/Debbie codes and helps others learn Playwright, testing, React, Nuxt and more/);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Debbie’s Zephyr Cloud contract has ended. This PR removes **current-employer** Zephyr framing from home/about/meta/homepage surface copy, and updates the About affiliation paragraph to Debbie’s signed-off agents-first bio. Historical blog posts that mention Zephyr as product context are unchanged.

## About bio P2 (signed off)

**Before:**
> I am a Developer Educator focused on Playwright, testing and AI agents, a Google Developer Expert in web technologies, and a Nuxt Ambassador. I previously worked in Developer Relations at Nuxt and as a Platform Engineer for Applied AI at Zephyr Cloud. I am also a former Microsoft Most Valuable Professional in developer technologies, Cloudinary Media Developer Expert, and GitHub Star Alumni.

**After (exact):**
> I help people work with AI agents. I build and use multi-agent workflows every day. I was a Principal Technical Program Manager at Microsoft, focused on Playwright. I am a Google Developer Expert in web technologies, and a former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star.

P1/P3/P4 left unchanged. No ambassadors program / “led the Playwright community” wording. Zephyr and Nuxt Ambassador are not in this paragraph.

## Other strings changed

| Location | Before | After |
|---|---|---|
| `components/CreativeHero.vue` (home hero subtitle) | `Platform Engineer – Applied AI at Zephyr Cloud` | `Developer Educator focused on Playwright, testing & AI agents` |
| `app.vue` (`description` / `og:description`) | `…Platform Engineer – Applied AI at Zephyr Cloud…` / `Previous Microsoft Most Valuable Professional` | `…Developer Educator focused on Playwright, testing & AI agents…` / `Former Microsoft Most Valuable Professional` |
| `server/routes/feed.xml.ts` (RSS feed description) | `…Platform Engineer – Applied AI at Zephyr Cloud…` | `…Developer Educator focused on Playwright, testing & AI agents…` |
| `content/podcasts/dotnet-rocks-ai-testing.md` (homepage recent-podcast blurb) | `…in her new role at Zephyr…` / `…joining Zephyr…` | `…drawing on her work at Zephyr Cloud.` (no current-job framing) |

## Tests / plan

- Playwright expectations updated in `tests/about-page.spec.ts`, `tests/home.spec.ts`, `tests/home-featured-content.spec.ts`, `tests/verify-home-page-header-and-introduction.spec.ts`
- `specs/test-plan.md` overview + home subtitle expected result

## Left unchanged on purpose

- Dated blog posts that reference Zephyr Cloud / The AI Platform as product context
- About page awards section still lists Nuxt Ambassador as a credential card (not in the opening affiliation paragraph)
- About page’s own page-level meta in `pages/about.vue` (already had no Zephyr employer wording)

## Review notes

- Copilot comment on `app.vue` Previous → Former MVP wording addressed
- Please do **not** merge until CoS/Debbie review

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38e9dda9-d7b9-4a0a-8e3d-bbb27f3f7106?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38e9dda9-d7b9-4a0a-8e3d-bbb27f3f7106&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

