### PR TITLE
Add Cloud Agent development environment configuration

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "debbie.codes",
+  "install": "npm ci && npx playwright install --with-deps chromium",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "npm run dev"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for this Nuxt 4 site by adding `.cursor/environment.json`.

The configuration:
- `install`: `npm ci && npx playwright install --with-deps chromium` — installs dependencies (runs `nuxt prepare` via `postinstall`) and the Chromium browser used by the Playwright test suite.
- `terminals`: starts the Nuxt dev server (`npm run dev`) on `http://127.0.0.1:8000`, matching `nuxt.config.ts` and `playwright.config.ts`.

## Validation

Verified end to end on the VM:
- `npm ci` completes (including the native `better-sqlite3` build and `nuxt prepare`) and is idempotent across two runs.
- Dev server boots and serves the homepage (HTTP 200, correct `<title>`).
- Full Playwright suite: **106 passed, 10 skipped**.
- Manual GUI walkthrough in Chrome: homepage, blog list, blog search (filtered to 27 results for "playwright"), blog post detail, videos page, and light/dark color-mode toggle — all working.

Verified with a prebuilt environment build:
- Draft build `bld-20260901-f7319884-1013-4b8b-a93a-cc398c1628cd` **SUCCEEDED** (install ran on a fresh checkout).
- A fresh Cloud Agent booted from that build confirmed: Node v22.14.0, pre-installed `node_modules` + generated `.nuxt`, Playwright Chromium present, dev server HTTP 200, and `tests/home.spec.ts` passing (3 passed, 2 skipped).

Note: `npm run lint` fails due to a pre-existing repo eslint config issue (`eslint.config.js` references `@typescript-eslint/semi` → `ts/semi`, which the current `@antfu/eslint-config` no longer exposes). This is unrelated to environment setup and is left unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a66897d-4e95-4505-8772-09fa98750c02?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a66897d-4e95-4505-8772-09fa98750c02&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

