### PR TITLE
perf: slim content queries for lists and search

### DIFF
--- a/components/FeaturedPodcast.vue
+++ b/components/FeaturedPodcast.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // Fetch the featured podcast dynamically
-const { data: featuredPodcast } = await useAsyncData('featured-podcast', () => 
+const { data: featuredPodcast } = await useAsyncData('featured-podcast', () =>
   queryCollection('podcasts')
+    .select(...podcastPreviewFields)
     .where('featured', '=', true)
     .order('date', 'DESC')
     .first()

--- a/content.config.ts
+++ b/content.config.ts
@@ -78,6 +78,7 @@ export default defineContentConfig({
         date: z.string(),
         description: z.string(),
         video: z.string(),
+        start: z.number().optional(),
         tags: z.array(z.string()),
         host: z.string().optional(),
         conference: z.string().optional(),

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -6,12 +6,14 @@ const isSearchActive = ref(false)
 
 // Fetch recent blog posts (latest 8)
 const { data: recentPosts } = await useAsyncData('recent-blog-posts', () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .order('date', 'DESC')
   .limit(8)
   .all())
 
 // Get all unique tags with counts for "Browse by Topic" section and years
 const { data: allPosts } = await useAsyncData('all-blog-posts-for-tags', () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .all())
 
 const popularTags = computed(() => {

--- a/pages/blog/page/[number].vue
+++ b/pages/blog/page/[number].vue
@@ -10,6 +10,7 @@ const offset = (page - 1) * postsPerPage
 
 // Fetch paginated posts
 const { data: posts } = await useAsyncData(`blog-page-${page}`, () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .order('date', 'DESC')
   .limit(postsPerPage)
   .skip(offset)
@@ -21,6 +22,7 @@ const { data: totalCount } = await useAsyncData('blog-total-count', () => queryC
 
 // Fetch all posts for search functionality
 const { data: allPosts } = await useAsyncData('all-blog-posts', () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .order('date', 'DESC')
   .all())
 

--- a/pages/blog/tags/[slug].vue
+++ b/pages/blog/tags/[slug].vue
@@ -6,6 +6,7 @@ const {
 } = useRoute()
 
 const { data: articles } = await useAsyncData(`articles-${slug}`, () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .where('tags', 'LIKE', `%${slug}%`)
   .order('date', 'DESC')
   .all())

--- a/pages/blog/tags/[tag].vue
+++ b/pages/blog/tags/[tag].vue
@@ -7,6 +7,7 @@ const { tag } = useRoute().params
 const normalizedUrlTag = (tag as string).toLowerCase().replace(/\s+/g, '-')
 
 const { data: articles } = await useAsyncData('articles', () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .order('date', 'DESC')
   .all())
 

--- a/pages/blog/year/[year].vue
+++ b/pages/blog/year/[year].vue
@@ -11,6 +11,7 @@ if (!/^\d{4}$/.test(year)) {
 
 // Fetch all posts and filter by year on the client side
 const { data: allArticles } = await useAsyncData(`blog-year-${year}`, () => queryCollection('blog')
+  .select(...blogPreviewFields)
   .order('date', 'DESC')
   .all())
 

--- a/pages/courses/index.vue
+++ b/pages/courses/index.vue
@@ -6,6 +6,7 @@ const isSearchActive = ref(false)
 
 // Get all courses to extract real tags
 const { data: allCourses } = await useAsyncData('all-courses-for-tags', () => queryCollection('courses')
+  .select(...coursePreviewFields)
   .order('date', 'DESC')
   .all())
 

--- a/pages/courses/tags/[slug].vue
+++ b/pages/courses/tags/[slug].vue
@@ -6,6 +6,7 @@ const {
 } = useRoute()
 
 const { data: courses } = await useAsyncData(`courses-${slug}`, () => queryCollection('courses')
+  .select(...coursePreviewFields)
   .where('tags', 'LIKE', `%${slug}%`)
   .order('date', 'DESC')
   .all())
@@ -15,6 +16,7 @@ const isSearchActive = ref(false)
 
 // Get all courses to extract real tags
 const { data: allCourses } = await useAsyncData('all-courses-for-tags-page', () => queryCollection('courses')
+  .select(...coursePreviewFields)
   .all())
 
 const courseTags = computed(() => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 const { data: articles } = await useAsyncData('articles-home', () =>
-  queryCollection('blog').order('date', 'DESC').limit(6).all())
+  queryCollection('blog').select(...blogPreviewFields).order('date', 'DESC').limit(6).all())
 
 const { data: videos } = await useAsyncData('videos-home', () =>
-  queryCollection('videos').order('date', 'DESC').limit(5).all())
+  queryCollection('videos').select(...videoPreviewFields).order('date', 'DESC').limit(5).all())
 
 const { data: podcasts } = await useAsyncData('podcasts-home', () =>
-  queryCollection('podcasts').order('date', 'DESC').limit(2).all())
+  queryCollection('podcasts').select(...podcastPreviewFields).order('date', 'DESC').limit(2).all())
 
 const homeBody = ref<HTMLElement | null>(null)
 useScrollReveal(homeBody)

--- a/pages/podcasts/index.vue
+++ b/pages/podcasts/index.vue
@@ -4,7 +4,7 @@ import type { Sections } from '~/types'
 const filteredPodcasts = ref<any[]>([])
 const isSearchActive = ref(false)
 
-const { data: allPodcasts } = await useAsyncData('podcasts', () => queryCollection('podcasts').order('date', 'DESC').all())
+const { data: allPodcasts } = await useAsyncData('podcasts', () => queryCollection('podcasts').select(...podcastPreviewFields).order('date', 'DESC').all())
 
 // Filter out featured podcasts from the main list (podcasts with featured: true)
 const podcasts = computed(() => {

--- a/pages/podcasts/tags/[slug].vue
+++ b/pages/podcasts/tags/[slug].vue
@@ -6,6 +6,7 @@ const {
 } = useRoute()
 
 const { data: podcasts } = await useAsyncData(`podcasts-${slug}`, () => queryCollection('podcasts')
+  .select(...podcastPreviewFields)
   .where('tags', 'LIKE', `%${slug}%`)
   .order('date', 'DESC')
   .all())
@@ -15,6 +16,7 @@ const isSearchActive = ref(false)
 
 // Get all podcasts to extract real tags
 const { data: allPodcasts } = await useAsyncData('all-podcasts-for-tags-page', () => queryCollection('podcasts')
+  .select(...podcastPreviewFields)
   .all())
 
 const podcastTags = computed(() => {

--- a/pages/videos/all.vue
+++ b/pages/videos/all.vue
@@ -6,6 +6,7 @@ const isSearchActive = ref(false)
 
 // Get all videos to extract real tags
 const { data: allVideos } = await useAsyncData('all-videos-for-tags-all-page', () => queryCollection('videos')
+  .select(...videoPreviewFields)
   .all())
 
 const videoTags = computed(() => {

--- a/pages/videos/index.vue
+++ b/pages/videos/index.vue
@@ -6,6 +6,7 @@ const isSearchActive = ref(false)
 
 // Fetch all videos
 const { data: allVideos } = await useAsyncData('all-videos-for-pages', () => queryCollection('videos')
+  .select(...videoPreviewFields)
   .order('date', 'DESC')
   .all())
 

--- a/pages/videos/tags/[slug].vue
+++ b/pages/videos/tags/[slug].vue
@@ -6,6 +6,7 @@ const {
 } = useRoute()
 
 const { data: videos } = await useAsyncData(`videos-${slug}`, () => queryCollection('videos')
+  .select(...videoPreviewFields)
   .where('tags', 'LIKE', `%${slug}%`)
   .order('date', 'DESC')
   .all())
@@ -15,6 +16,7 @@ const isSearchActive = ref(false)
 
 // Get all videos to extract real tags
 const { data: allVideos } = await useAsyncData('all-videos-for-tags-page', () => queryCollection('videos')
+  .select(...videoPreviewFields)
   .all())
 
 const videoTags = computed(() => {

--- a/server/routes/feed.xml.ts
+++ b/server/routes/feed.xml.ts
@@ -26,6 +26,7 @@ export default defineEventHandler(async (event) => {
 
   // Query all published blog posts
   const posts = await queryCollection(event, 'blog')
+    .select('path', 'title', 'description', 'date', 'tags', 'canonical', 'published')
     .order('date', 'DESC')
     .all()
 

--- a/utils/content-preview.ts
+++ b/utils/content-preview.ts
@@ -1,0 +1,54 @@
+/**
+ * Field lists for list, search, and tag pages.
+ * Search only matches title, description, and tags — never fetch full markdown bodies.
+ */
+
+export const blogPreviewFields = [
+  'path',
+  'title',
+  'description',
+  'date',
+  'tags',
+  'image',
+  'provider',
+  'url',
+  'canonical',
+] as const
+
+export const videoPreviewFields = [
+  'path',
+  'title',
+  'description',
+  'date',
+  'tags',
+  'video',
+  'host',
+  'conference',
+  'image',
+  'featured',
+] as const
+
+export const podcastPreviewFields = [
+  'path',
+  'title',
+  'description',
+  'date',
+  'tags',
+  'url',
+  'image',
+  'host',
+  'provider',
+  'featured',
+] as const
+
+export const coursePreviewFields = [
+  'path',
+  'title',
+  'description',
+  'date',
+  'tags',
+  'url',
+  'image',
+  'provider',
+  'platform',
+] as const

--- a/utils/content-preview.ts
+++ b/utils/content-preview.ts
@@ -22,6 +22,7 @@ export const videoPreviewFields = [
   'date',
   'tags',
   'video',
+  'start',
   'host',
   'conference',
   'image',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Slim list/search queries so pages do not ship full markdown bodies.

## Why CI went red
Copilot asked to keep `start` on video list queries (`VideoCard` uses it). `start` was not in the videos collection schema, so Nuxt Content failed those `.select(...)` calls. `/` and `/videos` rendered without videos or tag chips, and `video-filters` / home featured tests timed out waiting for links that never appeared.

## Fix
- `content.config.ts`: optional `start` on the videos schema so the select is a real column.

## Verify
Re-run `video-filters` and home featured videos after this schema change. Deploy preview: https://deploy-preview-602--debbiecodes.netlify.app
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

