### PR TITLE
perf: size the nav avatar and homepage video thumbs

### DIFF
--- a/components/FeaturedVideoSection.vue
+++ b/components/FeaturedVideoSection.vue
@@ -20,6 +20,9 @@ const otherVideos = computed(() => props.list.slice(1))
           <img
             :src="youtubeThumbnail(mainVideo.video)"
             :alt="mainVideo.title"
+            width="1280"
+            height="720"
+            fetchpriority="high"
             class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
           >
         </div>
@@ -46,6 +49,8 @@ const otherVideos = computed(() => props.list.slice(1))
               :alt="video.title"
               width="128"
               height="72"
+              loading="lazy"
+              decoding="async"
               class="rounded-lg object-cover border border-gray-200 dark:border-gray-700"
             >
           </div>

--- a/components/TheTopBar.vue
+++ b/components/TheTopBar.vue
@@ -25,7 +25,7 @@ watch(() => route.fullPath, () => {
                 alt="Debbie O'Brien"
                 width="96"
                 height="96"
-                sizes="48px"
+                sizes="50px"
                 quality="80"
                 format="webp"
               />

--- a/components/TheTopBar.vue
+++ b/components/TheTopBar.vue
@@ -21,10 +21,11 @@ watch(() => route.fullPath, () => {
               <NuxtImg
                 provider="cloudinary"
                 class="rounded-full mr-4 profile-pic border-white border"
-                src="w_100,c_fill,ar_1:1,q_auto,fl_lossy,f_auto/v1589118478/debbie.codes/debbie-thumb_clt00n"
+                src="v1589118478/debbie.codes/debbie-thumb_clt00n"
                 alt="Debbie O'Brien"
-                width="100"
-                height="auto"
+                width="96"
+                height="96"
+                sizes="48px"
                 quality="80"
                 format="webp"
               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wave A. Agent-mergeable after CI and a quick preview check.

## Why
The nav avatar requested 100px (and stacked Cloudinary transforms) for a 48px slot. Homepage side thumbs are 126px wide but still help layout if width/height are set. The featured thumbnail is LCP.

## What
- Nav `NuxtImg` uses the raw Cloudinary public id, 96x96 source, `sizes="48px"`
- Featured homepage video thumb has width/height and `fetchpriority="high"`
- Side-list thumbs stay 128x72 and load lazy

Keeps `hqdefault` YouTube posters. Switching to `mqdefault` would reintroduce 404s on older uploads.

## Verify
- Header photo still renders
- Homepage featured video still shows a poster
- Playwright: `npx playwright test tests/home.spec.ts tests/navigation.spec.ts`

## Merge
Wave A. A babysit/shipping agent may merge this when CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

