### PR TITLE
fix: SEO descriptions, skip link, and About accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,13 @@ Locally preview production build:
 npm run preview
 ```
 
+## Agent review loop (pstack)
+
+Install [pstack](https://cursor.com/marketplace/cursor/pstack) in Cursor before asking an agent to babysit or merge Wave A PRs:
+
+1. In Cursor chat, run `/add-plugin pstack`
+2. Run `/setup-pstack` and pick models
+3. On a Wave A PR: `/poteto-mode babysit this PR, then ship it if CI is green`
+
+Wave A PRs are agent-mergeable. Wave B PRs are human-merge only.
+

--- a/app.vue
+++ b/app.vue
@@ -92,8 +92,14 @@ useHead({
 
 <template>
   <div>
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-white focus:rounded-md"
+    >
+      Skip to content
+    </a>
     <TheTopBar />
-    <div class="lg:container mx-auto mt-top-bar px-2 md:px-4">
+    <div id="main-content" class="lg:container mx-auto mt-top-bar px-2 md:px-4">
       <NuxtPage />
     </div>
     <TheFooter />

--- a/app.vue
+++ b/app.vue
@@ -99,7 +99,7 @@ useHead({
       Skip to content
     </a>
     <TheTopBar />
-    <div id="main-content" class="lg:container mx-auto mt-top-bar px-2 md:px-4">
+    <div id="main-content" tabindex="-1" class="lg:container mx-auto mt-top-bar px-2 md:px-4">
       <NuxtPage />
     </div>
     <TheFooter />

--- a/components/ColorMode.vue
+++ b/components/ColorMode.vue
@@ -1,26 +1,27 @@
 <script setup lang="ts">
 type Theme = 'light' | 'dark' | 'system'
+
+const nextTheme = computed<Theme>(() => {
+  const current = useColorMode().preference
+  if (current === 'system')
+    return 'dark'
+  if (current === 'dark')
+    return 'light'
+  return 'system'
+})
+
 function setColorTheme(newTheme: Theme) {
   useColorMode().preference = newTheme
 }
 
 function cycleColorMode() {
-  const current = useColorMode().preference
-  if (current === 'system') {
-    setColorTheme('dark')
-  }
-  else if (current === 'dark') {
-    setColorTheme('light')
-  }
-  else {
-    setColorTheme('system')
-  }
+  setColorTheme(nextTheme.value)
 }
 </script>
 
 <template>
   <button
-    :aria-label="$colorMode.preference"
+    :aria-label="`${$colorMode.preference}. Switch to ${nextTheme}`"
     type="button"
     class="block"
     @click="cycleColorMode"

--- a/components/TagChip.vue
+++ b/components/TagChip.vue
@@ -48,9 +48,9 @@ withDefaults(defineProps<{
 }
 
 .dark .tag-chip--pill {
-  border-color: rgb(55 65 81);
-  background: rgba(15, 23, 42, 0.6);
-  color: rgb(209 213 219);
+  border-color: rgb(75 85 99);
+  background: rgb(30 41 59);
+  color: rgb(243 244 246);
 }
 
 .dark .tag-chip--pill:hover {

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -22,7 +22,7 @@
           class="
             text-white
             transition
-            hover:text-white
+            hover:text-primary
           "
         >
           <IconX class="h-10 w-10 mb-6" />
@@ -38,7 +38,7 @@
           class="
             text-white
             transition
-            hover:text-white
+            hover:text-primary
           "
         >
           <IconLinkedIn class="h-10 w-10" />
@@ -54,7 +54,7 @@
           class="
             text-white
             transition
-            hover:text-white
+            hover:text-primary
           "
         >
           <IconYouTube class="h-10 w-10" />
@@ -69,7 +69,7 @@
           class="
             text-white
             transition
-            hover:text-white
+            hover:text-primary
           "
         >
           <IconTwitch class="h-10 w-10" />
@@ -85,7 +85,7 @@
           class="
             text-white
             transition
-            hover:text-white
+            hover:text-primary
           "
         >
           <IconGitHub class="h-10 w-10" />
@@ -100,7 +100,7 @@
           class="
             text-white
             transition
-            hover:text-white
+            hover:text-primary
           "
         >
           <IconDevto class="h-10 w-10" />
@@ -113,6 +113,7 @@
           aria-label="buy me a coffee"
           target="_blank"
           rel="nofollow noopener noreferrer"
+          class="text-white transition hover:text-primary"
         >
           <IconCoffee class="h-10 w-10" />
         </a>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -149,7 +149,6 @@ useHead({
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center text-gray-600 dark:text-gray-300 hover:text-primary font-medium text-sm transition-colors"
-                :aria-label="`Learn more about ${award.name} (opens in new tab)`"
               >
                 About {{ award.name }}
                 <svg class="w-4 h-4 ml-1" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -120,10 +120,12 @@ useHead({
         </div>
 
         <section aria-labelledby="awards-heading">
-          <div class="animated-section stagger-children grid gap-6 md:grid-cols-2 lg:grid-cols-3" role="list">
-            <article
+          <ul class="animated-section stagger-children grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <li
               v-for="award in awards"
               :key="award.name"
+            >
+            <article
               class="group rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 p-6 transition-colors duration-200 hover:border-gray-400 dark:hover:border-gray-500"
             >
               <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-primary transition-colors">
@@ -149,13 +151,14 @@ useHead({
                 class="inline-flex items-center text-gray-600 dark:text-gray-300 hover:text-primary font-medium text-sm transition-colors"
                 :aria-label="`Learn more about ${award.name} (opens in new tab)`"
               >
-                Learn More
+                About {{ award.name }}
                 <svg class="w-4 h-4 ml-1" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                   <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
                 </svg>
               </a>
             </article>
-          </div>
+            </li>
+          </ul>
         </section>
       </div>
     </section>

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -39,7 +39,7 @@ useHead({
     { property: 'og:type', content: 'website' },
     {
       property: 'og:url',
-      content: 'https://debbie.codes',
+      content: `https://debbie.codes/blog/${slug}`,
     },
     {
       property: 'og:title',

--- a/pages/courses/index.vue
+++ b/pages/courses/index.vue
@@ -30,7 +30,7 @@ const courseTags = computed(() => {
 })
 
 const title: string = 'Courses'
-const description: string = ''
+const description: string = 'Workshops and courses on Playwright, Vue, Nuxt, and building with AI agents.'
 const section: Sections = 'courses'
 
 useHead({

--- a/pages/podcasts/index.vue
+++ b/pages/podcasts/index.vue
@@ -35,7 +35,7 @@ const podcastTags = computed(() => {
 })
 
 const title: string = 'Podcasts'
-const description: string = ''
+const description: string = 'Podcast conversations on Playwright, testing, AI agents, and developer advocacy.'
 const section: Sections = 'podcasts'
 
 useHead({

--- a/pages/videos/index.vue
+++ b/pages/videos/index.vue
@@ -32,7 +32,7 @@ const videoTags = computed(() => {
 })
 
 const title: string = 'Videos'
-const description: string = ''
+const description: string = 'Conference talks, interviews, and live streams on Playwright, testing, and AI agents.'
 const section: Sections = 'videos'
 
 useHead({

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -54,9 +54,8 @@ test.describe('About Page', () => {
                     - /url: https://stars.github.com/alumni/
                     - text: GitHub Star Alumni
                 - paragraph
-                - link "Learn more about GitHub Star Alumni (opens in new tab)":
+                - link "About GitHub Star Alumni":
                   - /url: https://stars.github.com/alumni/
-                  - text: About GitHub Star Alumni
             - listitem:
               - article:
                 - heading "Learn more about Google Developer Expert (opens in new tab)" [level=3]:
@@ -64,9 +63,8 @@ test.describe('About Page', () => {
                     - /url: https://me.developers.google.com/u/115790798136433531532
                     - text: Google Developer Expert
                 - paragraph
-                - link "Learn more about Google Developer Expert (opens in new tab)":
+                - link "About Google Developer Expert":
                   - /url: https://me.developers.google.com/u/115790798136433531532
-                  - text: About Google Developer Expert
             - listitem:
               - article:
                 - heading "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)" [level=3]:
@@ -74,9 +72,8 @@ test.describe('About Page', () => {
                     - /url: https://mvp.microsoft.com/en-us/PublicProfile/5003613?fullName=Debbie%20O%27Brien
                     - text: Former Microsoft Most Valuable Professional
                 - paragraph
-                - link "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)":
+                - link "About Former Microsoft Most Valuable Professional":
                   - /url: https://mvp.microsoft.com/en-us/PublicProfile/5003613?fullName=Debbie%20O%27Brien
-                  - text: About Former Microsoft Most Valuable Professional
             - listitem:
               - article:
                 - heading "Learn more about Nuxt Ambassador (opens in new tab)" [level=3]:
@@ -84,9 +81,8 @@ test.describe('About Page', () => {
                     - /url: https://nuxtjs.org/teams/
                     - text: Nuxt Ambassador
                 - paragraph
-                - link "Learn more about Nuxt Ambassador (opens in new tab)":
+                - link "About Nuxt Ambassador":
                   - /url: https://nuxtjs.org/teams/
-                  - text: About Nuxt Ambassador
             - listitem:
               - article:
                 - heading "Learn more about Media Developer Expert (opens in new tab)" [level=3]:
@@ -94,9 +90,8 @@ test.describe('About Page', () => {
                     - /url: https://cloudinary.com/mde
                     - text: Media Developer Expert
                 - paragraph
-                - link "Learn more about Media Developer Expert (opens in new tab)":
+                - link "About Media Developer Expert":
                   - /url: https://cloudinary.com/mde
-                  - text: About Media Developer Expert
             - listitem:
               - article:
                 - heading "Learn more about Auth0 Ambassador (opens in new tab)" [level=3]:
@@ -104,9 +99,8 @@ test.describe('About Page', () => {
                     - /url: https://auth0.com/ambassador-program/
                     - text: Auth0 Ambassador
                 - paragraph
-                - link "Learn more about Auth0 Ambassador (opens in new tab)":
+                - link "About Auth0 Ambassador":
                   - /url: https://auth0.com/ambassador-program/
-                  - text: About Auth0 Ambassador
             - listitem:
               - article:
                 - heading "Learn more about Microsoft Certified (opens in new tab)" [level=3]:
@@ -114,9 +108,8 @@ test.describe('About Page', () => {
                     - /url: https://www.youracclaim.com/badges/2bb11106-cef6-4a1c-9618-1ba63b413377
                     - text: Microsoft Certified
                 - paragraph
-                - link "Learn more about Microsoft Certified (opens in new tab)":
+                - link "About Microsoft Certified":
                   - /url: https://www.youracclaim.com/badges/2bb11106-cef6-4a1c-9618-1ba63b413377
-                  - text: About Microsoft Certified
             - listitem:
               - article:
                 - heading "Learn more about Bachelor's Level Diploma (opens in new tab)" [level=3]:
@@ -124,9 +117,8 @@ test.describe('About Page', () => {
                     - /url: https://openclassrooms.com/en/paths/315-front-end-developer
                     - text: Bachelor's Level Diploma
                 - paragraph
-                - link "Learn more about Bachelor's Level Diploma (opens in new tab)":
+                - link "About Bachelor's Level Diploma":
                   - /url: https://openclassrooms.com/en/paths/315-front-end-developer
-                  - text: About Bachelor's Level Diploma
             - listitem:
               - article:
                 - heading "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)" [level=3]:
@@ -134,9 +126,8 @@ test.describe('About Page', () => {
                     - /url: https://teamtreehouse.com/techdegree
                     - text: Full Stack JavaScript Tech Degree
                 - paragraph
-                - link "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)":
+                - link "About Full Stack JavaScript Tech Degree":
                   - /url: https://teamtreehouse.com/techdegree
-                  - text: About Full Stack JavaScript Tech Degree
       `);
     });
   });

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -47,87 +47,96 @@ test.describe('About Page', () => {
       await expect(page.getByRole('region')).toMatchAriaSnapshot(`
         - region:
           - list:
-            - article:
-              - heading "Learn more about GitHub Star Alumni (opens in new tab)" [level=3]:
+            - listitem:
+              - article:
+                - heading "Learn more about GitHub Star Alumni (opens in new tab)" [level=3]:
+                  - link "Learn more about GitHub Star Alumni (opens in new tab)":
+                    - /url: https://stars.github.com/alumni/
+                    - text: GitHub Star Alumni
+                - paragraph
                 - link "Learn more about GitHub Star Alumni (opens in new tab)":
                   - /url: https://stars.github.com/alumni/
-                  - text: GitHub Star Alumni
-              - paragraph
-              - link "Learn more about GitHub Star Alumni (opens in new tab)":
-                - /url: https://stars.github.com/alumni/
-                - text: Learn More
-            - article:
-              - heading "Learn more about Google Developer Expert (opens in new tab)" [level=3]:
+                  - text: About GitHub Star Alumni
+            - listitem:
+              - article:
+                - heading "Learn more about Google Developer Expert (opens in new tab)" [level=3]:
+                  - link "Learn more about Google Developer Expert (opens in new tab)":
+                    - /url: https://me.developers.google.com/u/115790798136433531532
+                    - text: Google Developer Expert
+                - paragraph
                 - link "Learn more about Google Developer Expert (opens in new tab)":
                   - /url: https://me.developers.google.com/u/115790798136433531532
-                  - text: Google Developer Expert
-              - paragraph
-              - link "Learn more about Google Developer Expert (opens in new tab)":
-                - /url: https://me.developers.google.com/u/115790798136433531532
-                - text: Learn More
-            - article:
-              - heading "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)" [level=3]:
+                  - text: About Google Developer Expert
+            - listitem:
+              - article:
+                - heading "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)" [level=3]:
+                  - link "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)":
+                    - /url: https://mvp.microsoft.com/en-us/PublicProfile/5003613?fullName=Debbie%20O%27Brien
+                    - text: Former Microsoft Most Valuable Professional
+                - paragraph
                 - link "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)":
                   - /url: https://mvp.microsoft.com/en-us/PublicProfile/5003613?fullName=Debbie%20O%27Brien
-                  - text: Former Microsoft Most Valuable Professional
-              - paragraph
-              - link "Learn more about Former Microsoft Most Valuable Professional (opens in new tab)":
-                - /url: https://mvp.microsoft.com/en-us/PublicProfile/5003613?fullName=Debbie%20O%27Brien
-                - text: Learn More
-            - article:
-              - heading "Learn more about Nuxt Ambassador (opens in new tab)" [level=3]:
+                  - text: About Former Microsoft Most Valuable Professional
+            - listitem:
+              - article:
+                - heading "Learn more about Nuxt Ambassador (opens in new tab)" [level=3]:
+                  - link "Learn more about Nuxt Ambassador (opens in new tab)":
+                    - /url: https://nuxtjs.org/teams/
+                    - text: Nuxt Ambassador
+                - paragraph
                 - link "Learn more about Nuxt Ambassador (opens in new tab)":
                   - /url: https://nuxtjs.org/teams/
-                  - text: Nuxt Ambassador
-              - paragraph
-              - link "Learn more about Nuxt Ambassador (opens in new tab)":
-                - /url: https://nuxtjs.org/teams/
-                - text: Learn More
-            - article:
-              - heading "Learn more about Media Developer Expert (opens in new tab)" [level=3]:
+                  - text: About Nuxt Ambassador
+            - listitem:
+              - article:
+                - heading "Learn more about Media Developer Expert (opens in new tab)" [level=3]:
+                  - link "Learn more about Media Developer Expert (opens in new tab)":
+                    - /url: https://cloudinary.com/mde
+                    - text: Media Developer Expert
+                - paragraph
                 - link "Learn more about Media Developer Expert (opens in new tab)":
                   - /url: https://cloudinary.com/mde
-                  - text: Media Developer Expert
-              - paragraph
-              - link "Learn more about Media Developer Expert (opens in new tab)":
-                - /url: https://cloudinary.com/mde
-                - text: Learn More
-            - article:
-              - heading "Learn more about Auth0 Ambassador (opens in new tab)" [level=3]:
+                  - text: About Media Developer Expert
+            - listitem:
+              - article:
+                - heading "Learn more about Auth0 Ambassador (opens in new tab)" [level=3]:
+                  - link "Learn more about Auth0 Ambassador (opens in new tab)":
+                    - /url: https://auth0.com/ambassador-program/
+                    - text: Auth0 Ambassador
+                - paragraph
                 - link "Learn more about Auth0 Ambassador (opens in new tab)":
                   - /url: https://auth0.com/ambassador-program/
-                  - text: Auth0 Ambassador
-              - paragraph
-              - link "Learn more about Auth0 Ambassador (opens in new tab)":
-                - /url: https://auth0.com/ambassador-program/
-                - text: Learn More
-            - article:
-              - heading "Learn more about Microsoft Certified (opens in new tab)" [level=3]:
+                  - text: About Auth0 Ambassador
+            - listitem:
+              - article:
+                - heading "Learn more about Microsoft Certified (opens in new tab)" [level=3]:
+                  - link "Learn more about Microsoft Certified (opens in new tab)":
+                    - /url: https://www.youracclaim.com/badges/2bb11106-cef6-4a1c-9618-1ba63b413377
+                    - text: Microsoft Certified
+                - paragraph
                 - link "Learn more about Microsoft Certified (opens in new tab)":
                   - /url: https://www.youracclaim.com/badges/2bb11106-cef6-4a1c-9618-1ba63b413377
-                  - text: Microsoft Certified
-              - paragraph
-              - link "Learn more about Microsoft Certified (opens in new tab)":
-                - /url: https://www.youracclaim.com/badges/2bb11106-cef6-4a1c-9618-1ba63b413377
-                - text: Learn More
-            - article:
-              - heading "Learn more about Bachelor's Level Diploma (opens in new tab)" [level=3]:
+                  - text: About Microsoft Certified
+            - listitem:
+              - article:
+                - heading "Learn more about Bachelor's Level Diploma (opens in new tab)" [level=3]:
+                  - link "Learn more about Bachelor's Level Diploma (opens in new tab)":
+                    - /url: https://openclassrooms.com/en/paths/315-front-end-developer
+                    - text: Bachelor's Level Diploma
+                - paragraph
                 - link "Learn more about Bachelor's Level Diploma (opens in new tab)":
                   - /url: https://openclassrooms.com/en/paths/315-front-end-developer
-                  - text: Bachelor's Level Diploma
-              - paragraph
-              - link "Learn more about Bachelor's Level Diploma (opens in new tab)":
-                - /url: https://openclassrooms.com/en/paths/315-front-end-developer
-                - text: Learn More
-            - article:
-              - heading "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)" [level=3]:
+                  - text: About Bachelor's Level Diploma
+            - listitem:
+              - article:
+                - heading "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)" [level=3]:
+                  - link "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)":
+                    - /url: https://teamtreehouse.com/techdegree
+                    - text: Full Stack JavaScript Tech Degree
+                - paragraph
                 - link "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)":
                   - /url: https://teamtreehouse.com/techdegree
-                  - text: Full Stack JavaScript Tech Degree
-              - paragraph
-              - link "Learn more about Full Stack JavaScript Tech Degree (opens in new tab)":
-                - /url: https://teamtreehouse.com/techdegree
-                - text: Learn More
+                  - text: About Full Stack JavaScript Tech Degree
       `);
     });
   });

--- a/tests/verify-awards-and-achievements-section.spec.ts
+++ b/tests/verify-awards-and-achievements-section.spec.ts
@@ -21,6 +21,6 @@ test.describe('About Page Content', () => {
     await expect(page.getByRole('heading', { name: 'Learn more about Google Developer Expert (opens in new tab)' })).toBeVisible();
     
     // Verify "Learn More" links are present
-    await expect(page.getByRole('link', { name: 'Learn More' }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: 'About GitHub Star Alumni' }).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wave A. Agent-mergeable after CI and a quick preview check.

## Why
Videos, podcasts, and courses had empty meta descriptions (SEO 92). About used `role="list"` on a div of articles. Theme toggle announced only `system`. Blog `og:url` always pointed at the homepage. Footer hover was white on white. Tag chips failed contrast.

## What
- Meta descriptions on videos, podcasts, and courses
- Skip link to `#main-content`
- Theme toggle label: `system. Switch to dark` (existing tests still match `system`)
- Blog post `og:url` uses the article path
- Awards are a real list; visible link text is `About {award}`
- Footer social hover uses primary red
- Dark tag chips use lighter text
- README notes how to install pstack for the merge loop

## Verify
- `/about` awards list still has 9 cards
- Color mode still cycles
- Playwright: `npx playwright test tests/about-page.spec.ts tests/color-mode.spec.ts tests/verify-awards-and-achievements-section.spec.ts`

## Merge
Wave A. A babysit/shipping agent may merge this when CI is green. Touches `pages/videos/index.vue` description only; rebase if #603 lands first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

