### PR TITLE
Add isolated verify driver plus About and Navigation recipes

### DIFF
--- a/.cursor/skills/verify-debbie-codes/SKILL.md
+++ b/.cursor/skills/verify-debbie-codes/SKILL.md
@@ -64,8 +64,10 @@ Mapped feature recipes (one command; captures evidence):
 
 ```bash
 node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive home --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive navigation --json
 node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive blog --json
 node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive videos --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive about --json
 node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive tags-and-search --json
 ```
 
@@ -114,6 +116,7 @@ If launch used `--reuse` on a server you did not start, cleanup will not kill th
 | Helper | Role |
 | --- | --- |
 | `control-debbie-codes.mjs` | Launch / doctor / drive / evidence / cleanup CLI (this skill). |
+| `bin/verify` | Isolated launch on port 8010 with its own process-group cleanup. Use when you must not share the default Playwright port. |
 | `npx playwright test` | Full regression suite already wired in CI. |
 | `.agents/skills/playwright-cli` | Interactive snapshot/click exploration when you need a human-style browser session — not a replacement for this skill’s proof loop. |
 

--- a/.cursor/skills/verify-debbie-codes/bin/drive.mjs
+++ b/.cursor/skills/verify-debbie-codes/bin/drive.mjs
@@ -37,7 +37,7 @@ async function aria(name, locator) {
 
 try {
   if (feature === 'home') {
-    await page.goto(`${baseURL}/`, { waitUntil: 'networkidle' })
+    await page.goto(`${baseURL}/`, { waitUntil: 'load' })
     await shot('home-before.png')
     const heading = page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })
     if (!(await heading.isVisible()))
@@ -53,16 +53,16 @@ try {
     log(`url ${page.url()}`)
   }
   else if (feature === 'navigation') {
-    await page.goto(`${baseURL}/`, { waitUntil: 'networkidle' })
+    await page.goto(`${baseURL}/`, { waitUntil: 'load' })
     await shot('navigation-before.png')
     const nav = page.getByRole('navigation')
-    await nav.getByRole('link', { name: 'about' }).click()
+    await nav.getByRole('link', { name: 'About', exact: true }).click()
     if (!/\/about\/?$/.test(page.url()))
       throw new Error(`navigation: expected /about, got ${page.url()}`)
-    await nav.getByRole('link', { name: 'videos' }).click()
+    await nav.getByRole('link', { name: 'Videos', exact: true }).click()
     if (!/\/videos\/?$/.test(page.url()))
       throw new Error(`navigation: expected /videos, got ${page.url()}`)
-    await nav.getByRole('link', { name: 'blog' }).click()
+    await nav.getByRole('link', { name: 'Blog', exact: true }).click()
     if (!/\/blog\/?$/.test(page.url()))
       throw new Error(`navigation: expected /blog, got ${page.url()}`)
     await aria('navigation.aria.yml', nav)
@@ -70,7 +70,7 @@ try {
     log(`url ${page.url()}`)
   }
   else if (feature === 'blog') {
-    await page.goto(`${baseURL}/blog`, { waitUntil: 'networkidle' })
+    await page.goto(`${baseURL}/blog`, { waitUntil: 'load' })
     await shot('blog-before.png')
     const search = page.getByRole('searchbox', { name: 'Search...' })
     await search.fill('playwright')
@@ -82,20 +82,19 @@ try {
     log(`search heading ${(await results.textContent())?.trim()}`)
   }
   else if (feature === 'videos') {
-    await page.goto(`${baseURL}/videos`, { waitUntil: 'networkidle' })
+    await page.goto(`${baseURL}/videos`, { waitUntil: 'load' })
     await shot('videos-before.png')
     const heading = page.getByRole('heading', { name: 'Videos', level: 1 })
     if (!(await heading.isVisible()))
       throw new Error('videos: h1 missing')
     const first = page.getByRole('article').first()
-    if (!(await first.isVisible()))
-      throw new Error('videos: no article')
+    await first.waitFor({ state: 'visible', timeout: 15000 })
     await aria('videos.aria.yml', page.getByRole('main'))
     await shot('videos-after.png')
     log(`url ${page.url()}`)
   }
   else if (feature === 'about') {
-    await page.goto(`${baseURL}/about`, { waitUntil: 'networkidle' })
+    await page.goto(`${baseURL}/about`, { waitUntil: 'load' })
     await shot('about-before.png')
     const heading = page.getByRole('heading', { name: /I'm Debbie O'Brien/i, level: 1 })
     if (!(await heading.isVisible()))

--- a/.cursor/skills/verify-debbie-codes/bin/drive.mjs
+++ b/.cursor/skills/verify-debbie-codes/bin/drive.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { chromium } from '@playwright/test'
+
+const baseURL = process.env.VERIFY_BASE_URL
+const artifactDir = process.env.VERIFY_ARTIFACT_DIR
+const feature = process.env.VERIFY_FEATURE
+
+if (!baseURL || !artifactDir || !feature) {
+  console.error('drive.mjs expects VERIFY_BASE_URL, VERIFY_ARTIFACT_DIR, VERIFY_FEATURE')
+  process.exit(2)
+}
+
+mkdirSync(artifactDir, { recursive: true })
+
+const logLines = []
+function log(line) {
+  logLines.push(line)
+  console.log(line)
+}
+
+const browser = await chromium.launch()
+const page = await browser.newPage({ viewport: { width: 1280, height: 800 } })
+
+async function shot(name) {
+  const path = `${artifactDir}/${name}`
+  await page.screenshot({ path, fullPage: false })
+  log(`screenshot ${path}`)
+}
+
+async function aria(name, locator) {
+  const yaml = await locator.ariaSnapshot()
+  const path = `${artifactDir}/${name}`
+  writeFileSync(path, yaml)
+  log(`aria ${path}`)
+}
+
+try {
+  if (feature === 'home') {
+    await page.goto(`${baseURL}/`, { waitUntil: 'networkidle' })
+    await shot('home-before.png')
+    const heading = page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })
+    if (!(await heading.isVisible()))
+      throw new Error('home: h1 Debbie O\'Brien missing')
+    const tagline = page.getByText('Developer Educator focused on Playwright, testing & AI agents')
+    if (!(await tagline.isVisible()))
+      throw new Error('home: tagline missing')
+    const videos = page.getByRole('region', { name: /Recent Videos/i })
+    if (!(await videos.isVisible()))
+      throw new Error('home: Recent Videos region missing')
+    await aria('home.aria.yml', page.getByRole('banner'))
+    await shot('home-after.png')
+    log(`url ${page.url()}`)
+  }
+  else if (feature === 'navigation') {
+    await page.goto(`${baseURL}/`, { waitUntil: 'networkidle' })
+    await shot('navigation-before.png')
+    const nav = page.getByRole('navigation')
+    await nav.getByRole('link', { name: 'about' }).click()
+    if (!/\/about\/?$/.test(page.url()))
+      throw new Error(`navigation: expected /about, got ${page.url()}`)
+    await nav.getByRole('link', { name: 'videos' }).click()
+    if (!/\/videos\/?$/.test(page.url()))
+      throw new Error(`navigation: expected /videos, got ${page.url()}`)
+    await nav.getByRole('link', { name: 'blog' }).click()
+    if (!/\/blog\/?$/.test(page.url()))
+      throw new Error(`navigation: expected /blog, got ${page.url()}`)
+    await aria('navigation.aria.yml', nav)
+    await shot('navigation-after.png')
+    log(`url ${page.url()}`)
+  }
+  else if (feature === 'blog') {
+    await page.goto(`${baseURL}/blog`, { waitUntil: 'networkidle' })
+    await shot('blog-before.png')
+    const search = page.getByRole('searchbox', { name: 'Search...' })
+    await search.fill('playwright')
+    const results = page.getByRole('heading', { name: /Search Results/ })
+    await results.waitFor({ state: 'visible', timeout: 10000 })
+    await aria('blog.aria.yml', page.getByRole('main'))
+    await shot('blog-after.png')
+    log(`url ${page.url()}`)
+    log(`search heading ${(await results.textContent())?.trim()}`)
+  }
+  else if (feature === 'videos') {
+    await page.goto(`${baseURL}/videos`, { waitUntil: 'networkidle' })
+    await shot('videos-before.png')
+    const heading = page.getByRole('heading', { name: 'Videos', level: 1 })
+    if (!(await heading.isVisible()))
+      throw new Error('videos: h1 missing')
+    const first = page.getByRole('article').first()
+    if (!(await first.isVisible()))
+      throw new Error('videos: no article')
+    await aria('videos.aria.yml', page.getByRole('main'))
+    await shot('videos-after.png')
+    log(`url ${page.url()}`)
+  }
+  else if (feature === 'about') {
+    await page.goto(`${baseURL}/about`, { waitUntil: 'networkidle' })
+    await shot('about-before.png')
+    const heading = page.getByRole('heading', { name: /I'm Debbie O'Brien/i, level: 1 })
+    if (!(await heading.isVisible()))
+      throw new Error('about: heading missing')
+    const awards = page.getByRole('heading', { name: 'Awards & Achievements', level: 2 })
+    if (!(await awards.isVisible()))
+      throw new Error('about: awards heading missing')
+    await aria('about.aria.yml', page.getByRole('main'))
+    await shot('about-after.png')
+    log(`url ${page.url()}`)
+  }
+  else {
+    throw new Error(`unknown feature ${feature}`)
+  }
+  writeFileSync(`${artifactDir}/${feature}.log`, `${logLines.join('\n')}\n`)
+}
+finally {
+  await browser.close()
+}

--- a/.cursor/skills/verify-debbie-codes/bin/drive.mjs
+++ b/.cursor/skills/verify-debbie-codes/bin/drive.mjs
@@ -115,10 +115,12 @@ try {
     const nav = page.getByRole('navigation')
     const headerLinks = [
       ['About', /\/about\/?$/],
+      ['Speaking', /\/speaking\/?$/],
       ['Videos', /\/videos\/?$/],
       ['Podcasts', /\/podcasts\/?$/],
       ['Courses', /\/courses\/?$/],
       ['Blog', /\/blog\/?$/],
+      ['Now', /\/now\/?$/],
     ]
     for (const [name, pattern] of headerLinks) {
       await clickUntilUrl(nav.getByRole('link', { name, exact: true }), pattern, `navigation ${name}`)

--- a/.cursor/skills/verify-debbie-codes/bin/drive.mjs
+++ b/.cursor/skills/verify-debbie-codes/bin/drive.mjs
@@ -99,7 +99,10 @@ try {
     if (podcastCount !== 2)
       throw new Error(`home: expected 2 podcast articles, got ${podcastCount}`)
 
-    await aria('home.aria.yml', page.getByRole('main'))
+    // Home is a set of regions, not a <main>. Prefer main when a later
+    // branch adds one; otherwise keep the page body plus header nav.
+    const homeMain = page.getByRole('main')
+    await aria('home.aria.yml', (await homeMain.count()) > 0 ? homeMain : page.locator('body'))
     await aria('home-nav.aria.yml', page.getByRole('navigation').first())
     await shot('home-after.png')
     log(`url ${page.url()}`)

--- a/.cursor/skills/verify-debbie-codes/bin/drive.mjs
+++ b/.cursor/skills/verify-debbie-codes/bin/drive.mjs
@@ -35,6 +35,38 @@ async function aria(name, locator) {
   log(`aria ${path}`)
 }
 
+async function clickUntilUrl(locator, pattern, label) {
+  const deadline = Date.now() + 15000
+  let lastError = ''
+  while (Date.now() < deadline) {
+    try {
+      await locator.click({ timeout: 3000 })
+      await page.waitForURL(pattern, { timeout: 2000 })
+      return
+    }
+    catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+  }
+  throw new Error(`${label}: expected ${pattern}, got ${page.url()} (${lastError})`)
+}
+
+async function retryUntil(label, fn, timeout = 10000) {
+  const deadline = Date.now() + timeout
+  let lastError = ''
+  while (Date.now() < deadline) {
+    try {
+      await fn()
+      return
+    }
+    catch (error) {
+      lastError = error instanceof Error ? error.message : String(error)
+    }
+    await page.waitForTimeout(200)
+  }
+  throw new Error(`${label}: ${lastError}`)
+}
+
 try {
   if (feature === 'home') {
     await page.goto(`${baseURL}/`, { waitUntil: 'load' })
@@ -45,26 +77,54 @@ try {
     const tagline = page.getByText('Developer Educator focused on Playwright, testing & AI agents')
     if (!(await tagline.isVisible()))
       throw new Error('home: tagline missing')
+
     const videos = page.getByRole('region', { name: /Recent Videos/i })
     if (!(await videos.isVisible()))
       throw new Error('home: Recent Videos region missing')
-    await aria('home.aria.yml', page.getByRole('banner'))
+    const videosLink = videos.getByRole('link', { name: /Recent Videos/i })
+    if (!/\/videos\/?$/.test(await videosLink.getAttribute('href') || ''))
+      throw new Error('home: Recent Videos heading is not a /videos link')
+
+    const blog = page.getByRole('region', { name: /Recent Blog Posts/i })
+    if (!(await blog.isVisible()))
+      throw new Error('home: Recent Blog Posts region missing')
+    const blogCount = await blog.getByRole('article').count()
+    if (blogCount !== 6)
+      throw new Error(`home: expected 6 blog articles, got ${blogCount}`)
+
+    const podcasts = page.getByRole('region', { name: /Recent Podcasts/i })
+    if (!(await podcasts.isVisible()))
+      throw new Error('home: Recent Podcasts region missing')
+    const podcastCount = await podcasts.getByRole('article').count()
+    if (podcastCount !== 2)
+      throw new Error(`home: expected 2 podcast articles, got ${podcastCount}`)
+
+    await aria('home.aria.yml', page.getByRole('main'))
+    await aria('home-nav.aria.yml', page.getByRole('navigation').first())
     await shot('home-after.png')
     log(`url ${page.url()}`)
+    log(`home blog articles ${blogCount}`)
+    log(`home podcast articles ${podcastCount}`)
   }
   else if (feature === 'navigation') {
     await page.goto(`${baseURL}/`, { waitUntil: 'load' })
     await shot('navigation-before.png')
     const nav = page.getByRole('navigation')
-    await nav.getByRole('link', { name: 'About', exact: true }).click()
-    if (!/\/about\/?$/.test(page.url()))
-      throw new Error(`navigation: expected /about, got ${page.url()}`)
-    await nav.getByRole('link', { name: 'Videos', exact: true }).click()
-    if (!/\/videos\/?$/.test(page.url()))
-      throw new Error(`navigation: expected /videos, got ${page.url()}`)
-    await nav.getByRole('link', { name: 'Blog', exact: true }).click()
-    if (!/\/blog\/?$/.test(page.url()))
-      throw new Error(`navigation: expected /blog, got ${page.url()}`)
+    const headerLinks = [
+      ['About', /\/about\/?$/],
+      ['Videos', /\/videos\/?$/],
+      ['Podcasts', /\/podcasts\/?$/],
+      ['Courses', /\/courses\/?$/],
+      ['Blog', /\/blog\/?$/],
+    ]
+    for (const [name, pattern] of headerLinks) {
+      await clickUntilUrl(nav.getByRole('link', { name, exact: true }), pattern, `navigation ${name}`)
+    }
+    await clickUntilUrl(
+      page.getByRole('link', { name: /Debbie O'Brien/i }).first(),
+      url => new URL(url).pathname === '/',
+      'navigation logo',
+    )
     await aria('navigation.aria.yml', nav)
     await shot('navigation-after.png')
     log(`url ${page.url()}`)
@@ -72,14 +132,24 @@ try {
   else if (feature === 'blog') {
     await page.goto(`${baseURL}/blog`, { waitUntil: 'load' })
     await shot('blog-before.png')
+    const heading = page.getByRole('heading', { name: 'Blog', level: 1 })
+    if (!(await heading.isVisible()))
+      throw new Error('blog: h1 missing')
     const search = page.getByRole('searchbox', { name: 'Search...' })
-    await search.fill('playwright')
+    await retryUntil('blog search', async () => {
+      await search.fill('playwright')
+      await page.getByRole('heading', { name: /Search Results/ }).waitFor({ state: 'visible', timeout: 2000 })
+    })
     const results = page.getByRole('heading', { name: /Search Results/ })
-    await results.waitFor({ state: 'visible', timeout: 10000 })
+    await page.getByRole('article').first().waitFor({ state: 'visible', timeout: 10000 })
+    const articleCount = await page.getByRole('article').count()
+    if (articleCount < 1)
+      throw new Error('blog: search returned no articles')
     await aria('blog.aria.yml', page.getByRole('main'))
     await shot('blog-after.png')
     log(`url ${page.url()}`)
     log(`search heading ${(await results.textContent())?.trim()}`)
+    log(`search articles ${articleCount}`)
   }
   else if (feature === 'videos') {
     await page.goto(`${baseURL}/videos`, { waitUntil: 'load' })
@@ -89,6 +159,9 @@ try {
       throw new Error('videos: h1 missing')
     const first = page.getByRole('article').first()
     await first.waitFor({ state: 'visible', timeout: 15000 })
+    const chip = page.getByRole('link', { name: '#playwright' }).first()
+    await clickUntilUrl(chip, /\/videos\/tags\/playwright\/?$/, 'videos tag')
+    await page.getByRole('article').first().waitFor({ state: 'visible', timeout: 15000 })
     await aria('videos.aria.yml', page.getByRole('main'))
     await shot('videos-after.png')
     log(`url ${page.url()}`)
@@ -102,9 +175,14 @@ try {
     const awards = page.getByRole('heading', { name: 'Awards & Achievements', level: 2 })
     if (!(await awards.isVisible()))
       throw new Error('about: awards heading missing')
+    const awardCards = page.getByRole('main').getByRole('article')
+    const awardCount = await awardCards.count()
+    if (awardCount !== 9)
+      throw new Error(`about: expected 9 award articles, got ${awardCount}`)
     await aria('about.aria.yml', page.getByRole('main'))
     await shot('about-after.png')
     log(`url ${page.url()}`)
+    log(`award articles ${awardCount}`)
   }
   else {
     throw new Error(`unknown feature ${feature}`)

--- a/.cursor/skills/verify-debbie-codes/bin/verify
+++ b/.cursor/skills/verify-debbie-codes/bin/verify
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Isolated launch / doctor / drive / cleanup for debbie.codes verification.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+PORT="${VERIFY_PORT:-8010}"
+RUN_ID="${VERIFY_RUN_ID:-default}"
+STATE_DIR="/tmp/verify-debbie-codes-${RUN_ID}"
+PID_FILE="${STATE_DIR}/nuxt.pid"
+LISTEN_PID_FILE="${STATE_DIR}/listen.pid"
+PORT_FILE="${STATE_DIR}/port"
+LOG_FILE="${STATE_DIR}/nuxt.log"
+ARTIFACT_DIR="${ROOT}/.cursor/skills/verify-debbie-codes/artifacts/${RUN_ID}"
+BASE_URL="${VERIFY_BASE_URL:-http://127.0.0.1:${PORT}}"
+
+usage() {
+  echo "Usage: VERIFY_PORT=8010 VERIFY_RUN_ID=<id> $0 launch|doctor|drive <feature>|cleanup" >&2
+  exit 2
+}
+
+ensure_state_dir() {
+  mkdir -p "${STATE_DIR}" "${ARTIFACT_DIR}"
+}
+
+is_ready() {
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 "${BASE_URL}/" || true)"
+  [[ "${code}" == "200" ]]
+}
+
+# Minified Nuxt HTML is one huge line; GNU grep can miss matches on it.
+html_has_title() {
+  python3 - "${BASE_URL}/" <<'PY'
+import sys, urllib.request
+url = sys.argv[1]
+html = urllib.request.urlopen(url, timeout=5).read().decode("utf-8", "replace")
+sys.exit(0 if "<title>Debbie" in html else 1)
+PY
+}
+
+cmd_launch() {
+  if [[ -n "${VERIFY_BASE_URL:-}" ]]; then
+    echo "VERIFY_BASE_URL is set (${VERIFY_BASE_URL}); skip launch and doctor that URL instead."
+    exit 1
+  fi
+  ensure_state_dir
+  if [[ -f "${PID_FILE}" ]] && kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
+    echo "Already running pid $(cat "${PID_FILE}") on $(cat "${PORT_FILE}")"
+    exit 0
+  fi
+  if curl -s -o /dev/null -w '%{http_code}' --max-time 1 "http://127.0.0.1:${PORT}/" | grep -qE '200|503'; then
+    echo "Port ${PORT} already answers. Pick another VERIFY_PORT; do not drive a shared instance."
+    exit 1
+  fi
+
+  cd "${ROOT}"
+  export NUXT_TELEMETRY_DISABLED=1
+  # nuxi --port overrides nuxt.config devServer.port (8000).
+  # New session so cleanup can kill the whole tree (npm + nuxi child) by pgid.
+  setsid npm run dev -- --port "${PORT}" --host 127.0.0.1 >"${LOG_FILE}" 2>&1 &
+  echo $! >"${PID_FILE}"
+  echo "${PORT}" >"${PORT_FILE}"
+
+  for _ in $(seq 1 90); do
+    if is_ready; then
+      lsof -iTCP:"${PORT}" -sTCP:LISTEN -t >"${LISTEN_PID_FILE}" || true
+      echo "Ready ${BASE_URL} pid $(cat "${PID_FILE}") listen $(tr '\n' ' ' <"${LISTEN_PID_FILE}")"
+      exit 0
+    fi
+    if ! kill -0 "$(cat "${PID_FILE}")" 2>/dev/null; then
+      echo "Dev server exited. Tail of ${LOG_FILE}:" >&2
+      tail -40 "${LOG_FILE}" >&2
+      exit 1
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for HTTP 200 on ${BASE_URL}" >&2
+  tail -40 "${LOG_FILE}" >&2
+  exit 1
+}
+
+cmd_doctor() {
+  if [[ -n "${VERIFY_BASE_URL:-}" ]]; then
+    if is_ready && html_has_title; then
+      echo "OK remote ${BASE_URL}"
+      exit 0
+    fi
+    echo "FAIL remote ${BASE_URL} not a ready debbie.codes instance" >&2
+    exit 1
+  fi
+  if [[ ! -f "${PID_FILE}" ]]; then
+    echo "FAIL no pid file ${PID_FILE}" >&2
+    exit 1
+  fi
+  local pid
+  pid="$(cat "${PID_FILE}")"
+  if ! kill -0 "${pid}" 2>/dev/null; then
+    echo "FAIL pid ${pid} is not running" >&2
+    exit 1
+  fi
+  local recorded_port
+  recorded_port="$(cat "${PORT_FILE}")"
+  if [[ "${recorded_port}" != "${PORT}" ]]; then
+    echo "FAIL VERIFY_PORT=${PORT} but this run recorded ${recorded_port}" >&2
+    exit 1
+  fi
+  if ! is_ready; then
+    echo "FAIL ${BASE_URL}/ is not HTTP 200" >&2
+    exit 1
+  fi
+  if ! html_has_title; then
+    echo "FAIL ${BASE_URL}/ HTML missing <title>Debbie" >&2
+    exit 1
+  fi
+  echo "OK pid ${pid} port ${PORT} ${BASE_URL}"
+}
+
+cmd_drive() {
+  local feature="${1:-}"
+  if [[ -z "${feature}" ]]; then
+    usage
+  fi
+  ensure_state_dir
+  cmd_doctor
+  export VERIFY_PORT="${PORT}"
+  export VERIFY_BASE_URL="${BASE_URL}"
+  export VERIFY_ARTIFACT_DIR="${ARTIFACT_DIR}"
+  export VERIFY_FEATURE="${feature}"
+  node "${ROOT}/.cursor/skills/verify-debbie-codes/bin/drive.mjs"
+}
+
+cmd_cleanup() {
+  if [[ -n "${VERIFY_BASE_URL:-}" ]]; then
+    echo "Remote URL set; nothing local to kill. Artifacts kept."
+    exit 0
+  fi
+  if [[ ! -f "${PID_FILE}" ]]; then
+    echo "No pid file; nothing to kill. Artifacts kept at ${ARTIFACT_DIR}"
+    exit 0
+  fi
+  local pid
+  pid="$(cat "${PID_FILE}")"
+  local pgid
+  pgid="$(ps -o pgid= -p "${pid}" 2>/dev/null | tr -d ' ' || true)"
+  if [[ -n "${pgid}" ]]; then
+    kill -- "-${pgid}" 2>/dev/null || true
+  elif kill -0 "${pid}" 2>/dev/null; then
+    kill "${pid}" 2>/dev/null || true
+  fi
+  if [[ -f "${LISTEN_PID_FILE}" ]]; then
+    while read -r listen_pid; do
+      [[ -n "${listen_pid}" ]] || continue
+      if kill -0 "${listen_pid}" 2>/dev/null; then
+        kill "${listen_pid}" 2>/dev/null || true
+      fi
+    done <"${LISTEN_PID_FILE}"
+  fi
+  for _ in $(seq 1 20); do
+    kill -0 "${pid}" 2>/dev/null || break
+    sleep 0.2
+  done
+  if [[ -n "${pgid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+    kill -9 -- "-${pgid}" 2>/dev/null || true
+  fi
+  rm -f "${PID_FILE}" "${PORT_FILE}" "${LISTEN_PID_FILE}"
+  echo "Stopped pid ${pid}. Artifacts kept at ${ARTIFACT_DIR}"
+}
+
+case "${1:-}" in
+  launch) cmd_launch ;;
+  doctor) cmd_doctor ;;
+  drive) shift; cmd_drive "${1:-}" ;;
+  cleanup) cmd_cleanup ;;
+  *) usage ;;
+esac

--- a/.cursor/skills/verify-debbie-codes/bin/verify
+++ b/.cursor/skills/verify-debbie-codes/bin/verify
@@ -83,34 +83,34 @@ cmd_doctor() {
   if [[ -n "${VERIFY_BASE_URL:-}" ]]; then
     if is_ready && html_has_title; then
       echo "OK remote ${BASE_URL}"
-      exit 0
+      return 0
     fi
     echo "FAIL remote ${BASE_URL} not a ready debbie.codes instance" >&2
-    exit 1
+    return 1
   fi
   if [[ ! -f "${PID_FILE}" ]]; then
     echo "FAIL no pid file ${PID_FILE}" >&2
-    exit 1
+    return 1
   fi
   local pid
   pid="$(cat "${PID_FILE}")"
   if ! kill -0 "${pid}" 2>/dev/null; then
     echo "FAIL pid ${pid} is not running" >&2
-    exit 1
+    return 1
   fi
   local recorded_port
   recorded_port="$(cat "${PORT_FILE}")"
   if [[ "${recorded_port}" != "${PORT}" ]]; then
     echo "FAIL VERIFY_PORT=${PORT} but this run recorded ${recorded_port}" >&2
-    exit 1
+    return 1
   fi
   if ! is_ready; then
     echo "FAIL ${BASE_URL}/ is not HTTP 200" >&2
-    exit 1
+    return 1
   fi
   if ! html_has_title; then
     echo "FAIL ${BASE_URL}/ HTML missing <title>Debbie" >&2
-    exit 1
+    return 1
   fi
   echo "OK pid ${pid} port ${PORT} ${BASE_URL}"
 }

--- a/.cursor/skills/verify-debbie-codes/control-debbie-codes.mjs
+++ b/.cursor/skills/verify-debbie-codes/control-debbie-codes.mjs
@@ -73,7 +73,7 @@ Commands:
 
   drive <feature> [--json]
       Run a mapped feature recipe end-to-end and capture evidence.
-      Features: home | blog | videos | tags-and-search
+      Features: home | navigation | blog | videos | about | tags-and-search
 
   evidence list|path [--json]
       List proof artifacts or print the evidence directory path.
@@ -624,8 +624,10 @@ async function screenshotCommand(flags) {
 async function driveFeature(feature, flags) {
   const recipes = {
     home: driveHome,
+    navigation: driveNavigation,
     blog: driveBlog,
     videos: driveVideos,
+    about: driveAbout,
     'tags-and-search': driveTagsAndSearch,
   }
   const fn = recipes[feature]
@@ -659,6 +661,79 @@ async function driveHome(page, state, flags) {
   return ok({
     message: `drove feature home; evidence in ${evidence}`,
     feature: 'home',
+    url: page.url(),
+    evidenceDir: evidence,
+    artifacts: [shot, snap],
+  }, { json: flags.json })
+}
+
+async function driveNavigation(page, state, flags) {
+  const { expect } = await import('@playwright/test')
+  const evidence = evidenceDirFor(state)
+  await page.goto(`${state.baseURL}/`, { waitUntil: 'domcontentloaded' })
+  const nav = page.getByRole('navigation')
+  const headerLinks = [
+    ['About', /\/about\/?$/],
+    ['Speaking', /\/speaking\/?$/],
+    ['Videos', /\/videos\/?$/],
+    ['Podcasts', /\/podcasts\/?$/],
+    ['Courses', /\/courses\/?$/],
+    ['Blog', /\/blog\/?$/],
+    ['Now', /\/now\/?$/],
+  ]
+  for (const [name, pattern] of headerLinks) {
+    await expect(async () => {
+      await nav.getByRole('link', { name, exact: true }).click()
+      await expect(page).toHaveURL(pattern, { timeout: 2000 })
+    }).toPass({ timeout: 15_000 })
+  }
+  await expect(async () => {
+    await page.getByRole('link', { name: /Debbie O'Brien/i }).first().click()
+    await expect(page).toHaveURL(url => new URL(url).pathname === '/', { timeout: 2000 })
+  }).toPass({ timeout: 15_000 })
+  const shot = join(evidence, 'navigation-proof.png')
+  const snap = join(evidence, 'navigation-proof.aria.txt')
+  await page.screenshot({ path: shot, fullPage: false })
+  writeFileSync(snap, `${await nav.first().ariaSnapshot()}\n`)
+  writeFileSync(join(evidence, 'navigation-proof.json'), `${JSON.stringify({
+    feature: 'navigation',
+    url: page.url(),
+    at: new Date().toISOString(),
+    artifacts: [shot, snap],
+  }, null, 2)}\n`)
+  return ok({
+    message: `drove feature navigation; evidence in ${evidence}`,
+    feature: 'navigation',
+    url: page.url(),
+    evidenceDir: evidence,
+    artifacts: [shot, snap],
+  }, { json: flags.json })
+}
+
+async function driveAbout(page, state, flags) {
+  const { expect } = await import('@playwright/test')
+  const evidence = evidenceDirFor(state)
+  await page.goto(`${state.baseURL}/about`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { level: 1, name: /I'm Debbie O'Brien/i })).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByRole('heading', { name: 'Awards & Achievements' })).toBeVisible()
+  await expect.poll(
+    () => page.getByRole('main').getByRole('article').count(),
+    { timeout: 15_000 },
+  ).toBe(9)
+  const shot = join(evidence, 'about-proof.png')
+  const snap = join(evidence, 'about-proof.aria.txt')
+  await page.screenshot({ path: shot })
+  writeFileSync(snap, `${await page.getByRole('main').ariaSnapshot()}\n`)
+  writeFileSync(join(evidence, 'about-proof.json'), `${JSON.stringify({
+    feature: 'about',
+    awardCount: await page.getByRole('main').getByRole('article').count(),
+    url: page.url(),
+    at: new Date().toISOString(),
+    artifacts: [shot, snap],
+  }, null, 2)}\n`)
+  return ok({
+    message: `drove feature about; evidence in ${evidence}`,
+    feature: 'about',
     url: page.url(),
     evidenceDir: evidence,
     artifacts: [shot, snap],

--- a/.cursor/skills/verify-debbie-codes/features/README.md
+++ b/.cursor/skills/verify-debbie-codes/features/README.md
@@ -41,6 +41,8 @@ Keep implementation details out of the map. Name only user paths, stable handles
 ## Features (sweep order)
 
 1. [Home](./home.md) — hero identity and recent content regions.
-2. [Blog](./blog.md) — listing, open article, back/prev/next chrome.
-3. [Videos](./videos.md) — videos index and topic tags.
-4. [Tags and search](./tags-and-search.md) — blog search box and tag filter pages.
+2. [Navigation](./navigation.md) — header links, theme chrome, and logo home.
+3. [Blog](./blog.md) — listing, open article, back/prev/next chrome.
+4. [Videos](./videos.md) — videos index and topic tags.
+5. [About](./about.md) — biography and awards grid.
+6. [Tags and search](./tags-and-search.md) — blog search box and tag filter pages.

--- a/.cursor/skills/verify-debbie-codes/features/about.md
+++ b/.cursor/skills/verify-debbie-codes/features/about.md
@@ -13,18 +13,19 @@ About is the biography and the awards grid.
 - Choose `About` in the header or footer.
 - Open `/about`.
 
-## Driving it with verify-debbie-codes
+## Driving it with control-debbie-codes
 
 Preconditions:
 
-- Doctor reports `OK`.
+- `control-debbie-codes.mjs doctor` reports healthy.
 
-- **Open about.** Run `.cursor/skills/verify-debbie-codes/bin/verify drive about`. The h1 matches `/I'm Debbie O'Brien/i`.
-- **Awards.** The h2 `Awards & Achievements` is visible. `main article` count is 9 (on `main` each award is an article).
-- **Proof.** `about-after.png` and `about.aria.yml` show the heading and the awards heading.
+- **Open about.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs goto /about`. The h1 matches `/I'm Debbie O'Brien/i`.
+- **Awards.** The h2 `Awards & Achievements` is visible. `main article` count is 9.
+- **One-shot recipe.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive about --json`. Evidence: `about-proof.png`, `about-proof.aria.txt`, `about-proof.json`.
+- **Isolated driver.** `.cursor/skills/verify-debbie-codes/bin/verify drive about` is the same path on port 8010.
 
 ## Gotchas
 
-- A Wave B branch rewrites the bio (Zephyr / Block past tense) and may add a headshot. Assert structure and current copy on the branch you are proving, not a remembered sentence from another PR.
-- Wave A may change award cards from `article` + `Learn more about …` to a list with visible `About {name}` text. Count roles from the page you launched.
+- Bio copy is past-tense on employment (Zephyr / Block). Assert structure and current copy, not a remembered sentence from an older PR.
+- Award cards are `article` items with visible `About {name}` text. Count roles from the page you launched.
 - Bio and awards both mention Google Developer Expert. Scope GDE sentences to `.prose` when the text appears twice.

--- a/.cursor/skills/verify-debbie-codes/features/about.md
+++ b/.cursor/skills/verify-debbie-codes/features/about.md
@@ -1,0 +1,30 @@
+# About
+
+About is the biography and the awards grid.
+
+## Sub-features
+
+- `about-hero` shows the About label and `I'm Debbie O'Brien` heading.
+- `about-bio` renders the markdown biography, including the YouTube Channel link.
+- `about-awards` lists nine award cards under Awards & Achievements.
+
+## How to get to it (user POV)
+
+- Choose `About` in the header or footer.
+- Open `/about`.
+
+## Driving it with verify-debbie-codes
+
+Preconditions:
+
+- Doctor reports `OK`.
+
+- **Open about.** Run `.cursor/skills/verify-debbie-codes/bin/verify drive about`. The h1 matches `/I'm Debbie O'Brien/i`.
+- **Awards.** The h2 `Awards & Achievements` is visible. `main article` count is 9 (on `main` each award is an article).
+- **Proof.** `about-after.png` and `about.aria.yml` show the heading and the awards heading.
+
+## Gotchas
+
+- A Wave B branch rewrites the bio (Zephyr / Block past tense) and may add a headshot. Assert structure and current copy on the branch you are proving, not a remembered sentence from another PR.
+- Wave A may change award cards from `article` + `Learn more about …` to a list with visible `About {name}` text. Count roles from the page you launched.
+- Bio and awards both mention Google Developer Expert. Scope GDE sentences to `.prose` when the text appears twice.

--- a/.cursor/skills/verify-debbie-codes/features/navigation.md
+++ b/.cursor/skills/verify-debbie-codes/features/navigation.md
@@ -1,6 +1,6 @@
 # Navigation
 
-Header and footer lists take a visitor to About, Videos, Podcasts, Courses, and Blog. On a narrow viewport the header list is behind Open menu.
+Header and footer lists take a visitor to About, Speaking, Videos, Podcasts, Courses, Blog, and Now. On a narrow viewport the header list is behind Open menu.
 
 ## Sub-features
 
@@ -15,20 +15,21 @@ Header and footer lists take a visitor to About, Videos, Podcasts, Courses, and 
 - Use the footer `contentinfo` list of page links.
 - On a 375-wide viewport, choose `Open menu`, then a header link.
 
-## Driving it with verify-debbie-codes
+## Driving it with control-debbie-codes
 
 Preconditions:
 
-- Doctor reports `OK`.
+- Doctor reports healthy.
 - Scope links to `navigation` or `contentinfo`. The same names exist in both.
 
-- **Desktop tour.** Run `.cursor/skills/verify-debbie-codes/bin/verify drive navigation`. After About, Videos, and Blog clicks the URL is `/blog`.
+- **Desktop tour.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive navigation --json`. After About, Speaking, Videos, Podcasts, Courses, Blog, and Now, the URL is `/now`.
 - **Logo.** Choose `Debbie O'Brien Debbie O'Brien`. The URL is `/`.
 - **Mobile open.** Set viewport 375×667. Choose `Open menu` until `Close menu` with text `✕` is visible, then choose `Videos`. The URL is `/videos` and the hamburger name is `Open menu` again.
-- **Proof.** `navigation-after.png` and `navigation.aria.yml` list About, Videos, Podcasts, Courses, Blog.
+- **Isolated driver.** `.cursor/skills/verify-debbie-codes/bin/verify drive navigation` walks the same header links, then logo home.
+- **Proof.** `navigation-proof.png` and `navigation-proof.aria.txt` list the header links.
 
 ## Gotchas
 
 - Clicks before hydration no-op. Retry until the URL or overlay actually changes (`tests/mobile-navigation.spec.ts`).
-- A Wave B branch may add Speaking and Now. On `main` those links are absent.
+- Current nav includes Speaking and Now. Do not assert the older five-link header.
 - Footer mobile coverage is skipped in `tests/navigation.spec.ts`; still prove footer on desktop.

--- a/.cursor/skills/verify-debbie-codes/features/navigation.md
+++ b/.cursor/skills/verify-debbie-codes/features/navigation.md
@@ -1,0 +1,34 @@
+# Navigation
+
+Header and footer lists take a visitor to About, Videos, Podcasts, Courses, and Blog. On a narrow viewport the header list is behind Open menu.
+
+## Sub-features
+
+- `nav-header` follows each desktop header link to the matching URL.
+- `nav-footer` follows each footer link (desktop).
+- `nav-logo` returns to `/`.
+- `nav-mobile` opens and closes the overlay and follows a link.
+
+## How to get to it (user POV)
+
+- Use the header `navigation` on viewports `lg` and up.
+- Use the footer `contentinfo` list of page links.
+- On a 375-wide viewport, choose `Open menu`, then a header link.
+
+## Driving it with verify-debbie-codes
+
+Preconditions:
+
+- Doctor reports `OK`.
+- Scope links to `navigation` or `contentinfo`. The same names exist in both.
+
+- **Desktop tour.** Run `.cursor/skills/verify-debbie-codes/bin/verify drive navigation`. After About, Videos, and Blog clicks the URL is `/blog`.
+- **Logo.** Choose `Debbie O'Brien Debbie O'Brien`. The URL is `/`.
+- **Mobile open.** Set viewport 375×667. Choose `Open menu` until `Close menu` with text `✕` is visible, then choose `Videos`. The URL is `/videos` and the hamburger name is `Open menu` again.
+- **Proof.** `navigation-after.png` and `navigation.aria.yml` list About, Videos, Podcasts, Courses, Blog.
+
+## Gotchas
+
+- Clicks before hydration no-op. Retry until the URL or overlay actually changes (`tests/mobile-navigation.spec.ts`).
+- A Wave B branch may add Speaking and Now. On `main` those links are absent.
+- Footer mobile coverage is skipped in `tests/navigation.spec.ts`; still prove footer on desktop.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased onto `main` after #608 landed. GitHub merge conflicts are gone.

#608 already shipped the primary skill (`control-debbie-codes.mjs`). This PR no longer replaces that work. The Files changed tab should now show only additive files:

- Isolated `bin/verify` + `bin/drive.mjs` (port 8010, own process group, safe remote doctor)
- About and Navigation feature recipes
- Those recipes wired into the landed CLI, including Speaking and Now in the header walk

Use `control-debbie-codes.mjs` for day-to-day verification. Use `bin/verify` only when you need an isolated preview that must not share port 8000.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

