### PR TITLE
Add project-local verify-debbie-codes verification skill

### DIFF
--- a/.cursor/skills/verify-debbie-codes/SKILL.md
+++ b/.cursor/skills/verify-debbie-codes/SKILL.md
@@ -5,7 +5,7 @@ description: "Drive the live debbie.codes Nuxt site (web UI) the way a user does
 
 # Verify debbie.codes
 
-Drive the **live** Nuxt 3 + Nuxt Content site at `http://127.0.0.1:8000` through the real browser path. Prefer this skill’s CLI (`control-debbie-codes.mjs`), which wraps the repo’s existing `@playwright/test` / Playwright stack. Do **not** invent a second browser automation stack. Leave `.agents/skills/playwright-cli` and `.agents/skills/add-content` alone; they are separate Debbie workflows.
+Drive the **live** Nuxt 3 + Nuxt Content site at `http://127.0.0.1:8000` through the real browser path. Prefer this skill’s CLI (`control-debbie-codes.mjs`), which wraps the repo’s existing `@playwright/test` / Playwright stack. Each drive command launches an ephemeral headless Chromium and closes it before exit (the Nuxt server stays up). Do **not** invent a second browser automation stack. Leave `.agents/skills/playwright-cli` and `.agents/skills/add-content` alone; they are separate Debbie workflows.
 
 `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs --help` lists commands, flags, and examples.
 

--- a/.cursor/skills/verify-debbie-codes/SKILL.md
+++ b/.cursor/skills/verify-debbie-codes/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: verify-debbie-codes
+description: "Drive the live debbie.codes Nuxt site (web UI) the way a user does via Playwright — launch the dev server, doctor health, exercise mapped features, capture screenshots/ARIA evidence, and clean up. Use when verifying UI changes, proving a feature works, or when asked to verify/test the site end-to-end."
+---
+
+# Verify debbie.codes
+
+Drive the **live** Nuxt 3 + Nuxt Content site at `http://127.0.0.1:8000` through the real browser path. Prefer this skill’s CLI (`control-debbie-codes.mjs`), which wraps the repo’s existing `@playwright/test` / Playwright stack. Do **not** invent a second browser automation stack. Leave `.agents/skills/playwright-cli` and `.agents/skills/add-content` alone; they are separate Debbie workflows.
+
+`node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs --help` lists commands, flags, and examples.
+
+## Pick a flow
+
+Interview facts for this repo:
+
+| Concern | Finding |
+| --- | --- |
+| Surface | Public marketing / content site (home, about, blog, videos, podcasts, courses). Primary: web UI. |
+| Run | `npm run dev` → Nuxt on `127.0.0.1:8000` (see `README.md`, `nuxt.config.ts` `devServer`, `.cursor/environment.json`). |
+| Drive | Existing Playwright harness (`playwright.config.ts`, `tests/*.spec.ts`, CI `.github/workflows/playwright.yml`). This skill’s CLI reuses Playwright; optional ad-hoc: `npx playwright test` or `.agents/skills/playwright-cli`. |
+| Observe | Screenshots + ARIA snapshots under `.cursor/skills/verify-debbie-codes/artifacts/<run-id>/`; HTTP identity; page URL/title. |
+| Isolate | Default port `8000`. One owned instance per state file in `/tmp/debbie-codes-verify/state.json`. Pass `--port` to launch another; pass `--reuse` to adopt an already-healthy server. Never kill a process this CLI did not start (`owned: false`). |
+
+## Launch
+
+From the repo root:
+
+```bash
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs launch --json
+# or adopt whatever is already answering on :8000
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs launch --reuse --json
+```
+
+Ready when `doctor` reports healthy (HTTP 200 and page HTML contains `Debbie`). The CLI waits up to 120s for Nuxt. Logs for a owned launch: `/tmp/debbie-codes-verify/<run-id>-nuxt.log`.
+
+Teardown is `cleanup` (below). Do not `pkill -f nuxt` / kill by process name.
+
+## Doctor
+
+Run first whenever anything looks off:
+
+```bash
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs doctor --json
+```
+
+Pass only when: base URL responds OK, identity string `Debbie` is present, and (if we own the process) the recorded pid is still alive. A failing doctor means relaunch or fix the environment before driving.
+
+## Drive
+
+Prefer stable ARIA handles used by this repo’s Playwright specs: roles (`heading`, `link`, `navigation`, `region`, `article`), accessible names, and the blog search placeholder `Search...`.
+
+Low-level (compose a custom path):
+
+```bash
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs goto /
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs expect --role heading --name "Debbie O'Brien"
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs click --role link --name Blog
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs fill --placeholder "Search..." --value playwright
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs expect --role heading --name "/Search Results/i"
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs expect-url "/\\/blog/"
+```
+
+Mapped feature recipes (one command; captures evidence):
+
+```bash
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive home --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive blog --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive videos --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive tags-and-search --json
+```
+
+Read the matching file under [`features/`](features/) before claiming a feature is verified. For broader coverage, also run the existing suite: `npx playwright test` (same app URL; config reuses a healthy server when not in CI).
+
+Hydration gotcha (from `tests/blog.spec.ts` / `tests/blog-filters.spec.ts`): cold loads can swallow the first nav click before the SPA router attaches. Retry click-until-URL when composing custom drives; the `drive` recipes already wait/`toPass` where needed.
+
+## Evidence
+
+Proof standards:
+
+- Exercise the **real user path** (nav links, listing → article, search box, tag chips) — not internal Nuxt APIs or content-collection queries as the primary proof.
+- Capture the **action and the resulting state** (URL + visible heading/region), not only a final screenshot.
+- Side effects here are mostly client-visible (filtered lists, tag pages). Confirm with ARIA snapshot + URL.
+- No mocks: talk to the running site.
+
+Artifacts live at:
+
+```text
+.cursor/skills/verify-debbie-codes/artifacts/<run-id>/
+```
+
+```bash
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs screenshot --out .cursor/skills/verify-debbie-codes/artifacts/manual.png
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs snapshot --out .cursor/skills/verify-debbie-codes/artifacts/manual.aria.txt
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs evidence list --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs evidence path
+```
+
+`drive <feature>` writes `*-proof.png`, `*-proof.aria.txt`, and `*-proof.json` into the current run’s evidence directory.
+
+## Cleanup
+
+```bash
+# see what would stop (never destructive without confirmation via omitting --dry-run)
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs cleanup --dry-run --json
+node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs cleanup --json
+```
+
+Cleanup stops the Nuxt process and Chromium session **this CLI started** (`owned: true`). It removes `/tmp/debbie-codes-verify/state.json` and ephemeral browser profile dirs under that temp folder. It **never** deletes `.cursor/skills/verify-debbie-codes/artifacts/`. After cleanup, confirm evidence still exists (`evidence list` or `ls` the path printed by cleanup).
+
+If launch used `--reuse` on a server you did not start, cleanup will not kill that server.
+
+## Helpers
+
+| Helper | Role |
+| --- | --- |
+| `control-debbie-codes.mjs` | Launch / doctor / drive / evidence / cleanup CLI (this skill). |
+| `npx playwright test` | Full regression suite already wired in CI. |
+| `.agents/skills/playwright-cli` | Interactive snapshot/click exploration when you need a human-style browser session — not a replacement for this skill’s proof loop. |
+
+Invocation from repo root only (paths are relative to the skill and resolve the repo root as three levels up from the skill file).
+
+## Feature map
+
+The behavior inventory lives in [`features/`](features/). Each file uses the same four H2s: `Sub-features`, `How to get to it (user POV)`, `Driving it with control-debbie-codes`, `Gotchas`.
+
+## Maintenance
+
+When routes, nav labels, or search UI change, update the matching `features/*.md` and `drive` recipes in the same PR, or run `/maintain-verification-skill` if that pstack skill is available.

--- a/.cursor/skills/verify-debbie-codes/control-debbie-codes.mjs
+++ b/.cursor/skills/verify-debbie-codes/control-debbie-codes.mjs
@@ -1,0 +1,1003 @@
+#!/usr/bin/env node
+/**
+ * Agent-friendly control CLI for verifying debbie.codes.
+ * Drive the live Nuxt site the way a user would, via Playwright (already in this repo).
+ *
+ * Usage: node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs <command> [options]
+ */
+
+import { spawn } from 'node:child_process'
+import {
+  accessSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { createServer } from 'node:http'
+import { homedir, tmpdir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import process from 'node:process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '../../..')
+const SKILL_DIR = __dirname
+const DEFAULT_PORT = 8000
+const DEFAULT_HOST = '127.0.0.1'
+const STATE_DIR = join(tmpdir(), 'debbie-codes-verify')
+const STATE_PATH = join(STATE_DIR, 'state.json')
+const ARTIFACTS_DIR = join(SKILL_DIR, 'artifacts')
+const READY_TIMEOUT_MS = 120_000
+const READY_POLL_MS = 500
+
+function usage(exitCode = 0) {
+  const text = `control-debbie-codes — drive the live debbie.codes Nuxt site for verification
+
+Usage:
+  node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs <command> [options]
+
+Commands:
+  launch [--port <n>] [--reuse] [--json]
+      Start \`npm run dev\` for this repo (or reuse a healthy server on the port).
+      Writes state under ${STATE_DIR}.
+
+  doctor [--json]
+      Read-only health check: HTTP 200 on base URL, title contains Debbie,
+      optional ownership of the process we launched.
+
+  info [--json]
+      Print current verification state (base URL, pid, evidence dir, browser CDP).
+
+  goto <path> [--json]
+      Open a path on the running site (e.g. /, /blog, /videos).
+
+  click --role <role> --name <name> [--exact] [--json]
+      Click by ARIA role + accessible name.
+
+  fill --placeholder <text> --value <value> [--json]
+      Fill an input matched by placeholder.
+
+  expect --role <role> --name <name> [--visible|--hidden] [--timeout <ms>] [--json]
+      Assert an element is visible (default) or hidden.
+
+  expect-url <pattern> [--timeout <ms>] [--json]
+      Assert the current URL matches a regex string.
+
+  snapshot [--out <path>] [--json]
+      Write an accessibility snapshot (YAML-ish text) to evidence or --out.
+
+  screenshot [--out <path>] [--full-page] [--json]
+      Capture a PNG screenshot to evidence or --out.
+
+  drive <feature> [--json]
+      Run a mapped feature recipe end-to-end and capture evidence.
+      Features: home | blog | videos | tags-and-search
+
+  evidence list|path [--json]
+      List proof artifacts or print the evidence directory path.
+
+  cleanup [--dry-run] [--json]
+      Stop the Nuxt process and browser this CLI started.
+      Never deletes evidence under artifacts/.
+
+Global:
+  --help, -h     Show this help
+  --json         Machine-readable JSON on stdout (errors still use stderr text)
+  --dry-run      For cleanup only: print what would be stopped without doing it
+
+Evidence survives cleanup at:
+  ${ARTIFACTS_DIR}/<run-id>/
+`
+  if (exitCode === 0)
+    console.log(text)
+  else
+    console.error(text)
+  process.exit(exitCode)
+}
+
+function parseArgs(argv) {
+  const args = { _: [], flags: {} }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--help' || a === '-h') {
+      args.flags.help = true
+    }
+    else if (a === '--json') {
+      args.flags.json = true
+    }
+    else if (a === '--dry-run') {
+      args.flags.dryRun = true
+    }
+    else if (a === '--reuse') {
+      args.flags.reuse = true
+    }
+    else if (a === '--exact') {
+      args.flags.exact = true
+    }
+    else if (a === '--visible') {
+      args.flags.visible = true
+    }
+    else if (a === '--hidden') {
+      args.flags.hidden = true
+    }
+    else if (a === '--full-page') {
+      args.flags.fullPage = true
+    }
+    else if (a.startsWith('--') && a.includes('=')) {
+      const [k, ...rest] = a.slice(2).split('=')
+      args.flags[camel(k)] = rest.join('=')
+    }
+    else if (a.startsWith('--')) {
+      const key = camel(a.slice(2))
+      const next = argv[i + 1]
+      if (next && !next.startsWith('--')) {
+        args.flags[key] = next
+        i++
+      }
+      else {
+        args.flags[key] = true
+      }
+    }
+    else {
+      args._.push(a)
+    }
+  }
+  return args
+}
+
+function camel(s) {
+  return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase())
+}
+
+function fail(message, { code = 1, json = false, details } = {}) {
+  if (json) {
+    console.log(JSON.stringify({ ok: false, error: message, ...(details || {}) }, null, 2))
+  }
+  else {
+    console.error(`error: ${message}`)
+    if (details)
+      console.error(details)
+  }
+  process.exit(code)
+}
+
+function ok(payload, { json = false } = {}) {
+  if (json)
+    console.log(JSON.stringify({ ok: true, ...payload }, null, 2))
+  else if (typeof payload === 'string')
+    console.log(payload)
+  else if (payload.message)
+    console.log(payload.message)
+  else
+    console.log(JSON.stringify(payload, null, 2))
+}
+
+function ensureDirs() {
+  mkdirSync(STATE_DIR, { recursive: true })
+  mkdirSync(ARTIFACTS_DIR, { recursive: true })
+}
+
+function readState() {
+  if (!existsSync(STATE_PATH))
+    return null
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'))
+  }
+  catch {
+    return null
+  }
+}
+
+function writeState(state) {
+  ensureDirs()
+  writeFileSync(STATE_PATH, `${JSON.stringify(state, null, 2)}\n`)
+}
+
+function clearState() {
+  if (existsSync(STATE_PATH))
+    rmSync(STATE_PATH)
+}
+
+function baseUrlFrom(stateOrPort) {
+  if (typeof stateOrPort === 'object' && stateOrPort?.baseURL)
+    return stateOrPort.baseURL.replace(/\/$/, '')
+  const port = typeof stateOrPort === 'number' ? stateOrPort : DEFAULT_PORT
+  return `http://${DEFAULT_HOST}:${port}`
+}
+
+function evidenceDirFor(state) {
+  const runId = state?.runId || 'default'
+  const dir = join(ARTIFACTS_DIR, runId)
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function resolveOutPath(state, out, fallbackName) {
+  if (out) {
+    const p = isAbsolute(out) ? out : resolve(process.cwd(), out)
+    mkdirSync(dirname(p), { recursive: true })
+    return p
+  }
+  const dir = evidenceDirFor(state)
+  return join(dir, fallbackName)
+}
+
+async function httpProbe(url, { timeoutMs = 5000 } = {}) {
+  const controller = new AbortController()
+  const t = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(url, { signal: controller.signal, redirect: 'follow' })
+    const text = await res.text()
+    return { status: res.status, ok: res.ok, text, headers: Object.fromEntries(res.headers) }
+  }
+  catch (err) {
+    return { status: 0, ok: false, error: err.message }
+  }
+  finally {
+    clearTimeout(t)
+  }
+}
+
+function pidAlive(pid) {
+  if (!pid || typeof pid !== 'number')
+    return false
+  try {
+    process.kill(pid, 0)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+function findFreePort() {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer()
+    server.listen(0, DEFAULT_HOST, () => {
+      const { port } = server.address()
+      server.close(err => (err ? reject(err) : resolvePort(port)))
+    })
+    server.on('error', reject)
+  })
+}
+
+async function waitForReady(url, { timeoutMs = READY_TIMEOUT_MS } = {}) {
+  const start = Date.now()
+  let lastError = ''
+  while (Date.now() - start < timeoutMs) {
+    const probe = await httpProbe(url, { timeoutMs: 2000 })
+    if (probe.ok && /Debbie/i.test(probe.text || ''))
+      return { ready: true, status: probe.status }
+    lastError = probe.error || `HTTP ${probe.status}`
+    await new Promise(r => setTimeout(r, READY_POLL_MS))
+  }
+  return { ready: false, error: lastError }
+}
+
+async function launchCommand(flags) {
+  ensureDirs()
+  const port = Number(flags.port || DEFAULT_PORT)
+  if (!Number.isInteger(port) || port < 1 || port > 65535)
+    fail(`invalid --port ${flags.port}`, { json: flags.json })
+
+  const baseURL = baseUrlFrom(port)
+  const existing = readState()
+  const probe = await httpProbe(baseURL)
+
+  if (probe.ok && /Debbie/i.test(probe.text || '')) {
+    if (!flags.reuse && existing?.pid && pidAlive(existing.pid) && existing.port === port) {
+      // Already our instance
+      const state = {
+        ...existing,
+        baseURL,
+        port,
+        reused: true,
+        checkedAt: new Date().toISOString(),
+      }
+      writeState(state)
+      return ok({
+        message: `Reusing healthy server we own at ${baseURL} (pid ${existing.pid})`,
+        baseURL,
+        port,
+        pid: existing.pid,
+        runId: state.runId,
+        evidenceDir: evidenceDirFor(state),
+        reused: true,
+      }, { json: flags.json })
+    }
+    if (flags.reuse || !existing) {
+      const runId = existing?.runId || `run-${Date.now()}`
+      const state = {
+        runId,
+        baseURL,
+        port,
+        pid: existing?.pid || null,
+        owned: false,
+        reused: true,
+        startedAt: existing?.startedAt || new Date().toISOString(),
+        evidenceDir: join(ARTIFACTS_DIR, runId),
+        repoRoot: REPO_ROOT,
+        browser: existing?.browser || null,
+      }
+      writeState(state)
+      mkdirSync(state.evidenceDir, { recursive: true })
+      return ok({
+        message: `Reusing already-running site at ${baseURL} (not owned by this CLI; cleanup will not stop it)`,
+        baseURL,
+        port,
+        owned: false,
+        runId,
+        evidenceDir: state.evidenceDir,
+        reused: true,
+      }, { json: flags.json })
+    }
+    fail(
+      `Port ${port} already serves debbie.codes but is not tracked as ours. Pass --reuse to adopt it, or pick another --port.`,
+      { json: flags.json, details: { baseURL, existingState: existing } },
+    )
+  }
+
+  if (probe.ok && !/Debbie/i.test(probe.text || '')) {
+    fail(
+      `Port ${port} is in use by something that is not debbie.codes (response missing Debbie identity). Choose another --port.`,
+      { json: flags.json },
+    )
+  }
+
+  const runId = `run-${Date.now()}`
+  const evidenceDir = join(ARTIFACTS_DIR, runId)
+  mkdirSync(evidenceDir, { recursive: true })
+  const logPath = join(STATE_DIR, `${runId}-nuxt.log`)
+
+  const child = spawn('npm', ['run', 'dev', '--', '--host', DEFAULT_HOST, '--port', String(port)], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, PORT: String(port) },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  })
+
+  const logFd = { stream: null }
+  try {
+    writeFileSync(logPath, '')
+  }
+  catch { /* ignore */ }
+
+  const appendLog = (chunk) => {
+    try {
+      writeFileSync(logPath, chunk, { flag: 'a' })
+    }
+    catch { /* ignore */ }
+  }
+  child.stdout.on('data', appendLog)
+  child.stderr.on('data', appendLog)
+
+  child.unref()
+
+  const pending = {
+    runId,
+    baseURL,
+    port,
+    pid: child.pid,
+    owned: true,
+    reused: false,
+    startedAt: new Date().toISOString(),
+    evidenceDir,
+    repoRoot: REPO_ROOT,
+    logPath,
+    browser: null,
+  }
+  writeState(pending)
+
+  const ready = await waitForReady(baseURL)
+  if (!ready.ready) {
+    try {
+      process.kill(-child.pid, 'SIGTERM')
+    }
+    catch {
+      try { process.kill(child.pid, 'SIGTERM') }
+      catch { /* ignore */ }
+    }
+    clearState()
+    fail(
+      `Nuxt did not become ready at ${baseURL} within ${READY_TIMEOUT_MS}ms: ${ready.error || 'unknown'}. See ${logPath}`,
+      { json: flags.json },
+    )
+  }
+
+  writeState({ ...pending, readyAt: new Date().toISOString() })
+  return ok({
+    message: `Launched Nuxt at ${baseURL} (pid ${child.pid})`,
+    baseURL,
+    port,
+    pid: child.pid,
+    owned: true,
+    runId,
+    evidenceDir,
+    logPath,
+  }, { json: flags.json })
+}
+
+async function doctorCommand(flags) {
+  const state = readState()
+  const port = Number(flags.port || state?.port || DEFAULT_PORT)
+  const baseURL = baseUrlFrom(state || port)
+  const probe = await httpProbe(`${baseURL}/`)
+  const titleMatch = /Debbie/i.test(probe.text || '')
+  const ownedAlive = Boolean(state?.owned && state?.pid && pidAlive(state.pid))
+  const browserAlive = Boolean(state?.browser?.cdpPort && await cdpAlive(state.browser.cdpPort))
+
+  const report = {
+    healthy: Boolean(probe.ok && titleMatch),
+    baseURL,
+    httpStatus: probe.status,
+    identityOk: titleMatch,
+    statePresent: Boolean(state),
+    ownedProcess: state?.owned || false,
+    pid: state?.pid || null,
+    pidAlive: state?.pid ? pidAlive(state.pid) : false,
+    ownedAlive,
+    browserCdp: state?.browser?.cdpPort || null,
+    browserAlive,
+    runId: state?.runId || null,
+    evidenceDir: state ? evidenceDirFor(state) : ARTIFACTS_DIR,
+    checkedAt: new Date().toISOString(),
+  }
+
+  if (!report.healthy) {
+    fail(
+      `doctor failed: site at ${baseURL} is not healthy (http=${probe.status}, identity=${titleMatch}). Run launch first.`,
+      { json: flags.json, details: report },
+    )
+  }
+
+  if (flags.json) {
+    return ok(report, { json: true })
+  }
+  console.log(`doctor: healthy`)
+  console.log(`  baseURL:     ${report.baseURL}`)
+  console.log(`  httpStatus:  ${report.httpStatus}`)
+  console.log(`  identity:    Debbie present`)
+  console.log(`  owned:       ${report.ownedProcess} (pid ${report.pid ?? 'n/a'}, alive=${report.pidAlive})`)
+  console.log(`  browserCdp:  ${report.browserCdp ?? 'not started'} (alive=${report.browserAlive})`)
+  console.log(`  evidence:    ${report.evidenceDir}`)
+  console.log(`  runId:       ${report.runId ?? 'n/a'}`)
+}
+
+async function infoCommand(flags) {
+  const state = readState()
+  if (!state) {
+    fail('no verification state; run launch first', { json: flags.json })
+  }
+  return ok({
+    message: `baseURL=${state.baseURL} runId=${state.runId}`,
+    ...state,
+    evidenceDir: evidenceDirFor(state),
+    pidAlive: state.pid ? pidAlive(state.pid) : false,
+  }, { json: flags.json })
+}
+
+async function cdpAlive(cdpPort) {
+  const probe = await httpProbe(`http://${DEFAULT_HOST}:${cdpPort}/json/version`, { timeoutMs: 1500 })
+  return probe.ok
+}
+
+async function loadPlaywright() {
+  try {
+    return await import('playwright')
+  }
+  catch {
+    fail(
+      'Playwright is not importable. From the repo root run: npm ci && npx playwright install chromium',
+      { json: false },
+    )
+  }
+}
+
+async function ensureBrowser(state, flags = {}) {
+  const { chromium } = await loadPlaywright()
+  if (state.browser?.cdpPort && await cdpAlive(state.browser.cdpPort)) {
+    const browser = await chromium.connectOverCDP(`http://${DEFAULT_HOST}:${state.browser.cdpPort}`)
+    const context = browser.contexts()[0] || await browser.newContext({ viewport: { width: 1280, height: 800 } })
+    const page = context.pages()[0] || await context.newPage()
+    return { browser, context, page, state, connected: true }
+  }
+
+  const cdpPort = await findFreePort()
+  const userDataDir = join(STATE_DIR, `browser-${state.runId || 'default'}`)
+  mkdirSync(userDataDir, { recursive: true })
+
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: true,
+    viewport: { width: 1280, height: 800 },
+    args: [`--remote-debugging-port=${cdpPort}`],
+  })
+  const page = context.pages()[0] || await context.newPage()
+  const browser = context.browser()
+
+  state.browser = {
+    cdpPort,
+    userDataDir,
+    startedAt: new Date().toISOString(),
+    owned: true,
+  }
+  writeState(state)
+
+  return { browser, context, page, state, connected: false }
+}
+
+async function withPage(flags, fn) {
+  const state = readState()
+  if (!state?.baseURL) {
+    fail('no verification state; run launch first', { json: flags.json })
+  }
+  const doctorProbe = await httpProbe(`${state.baseURL}/`)
+  if (!doctorProbe.ok) {
+    fail(`site not reachable at ${state.baseURL}; run doctor / launch`, { json: flags.json })
+  }
+
+  const session = await ensureBrowser(state, flags)
+  try {
+    return await fn(session.page, session.state, session)
+  }
+  finally {
+    // Keep browser alive across commands; cleanup closes it.
+  }
+}
+
+async function gotoCommand(pathArg, flags) {
+  if (!pathArg)
+    fail('goto requires a path (e.g. / or /blog)', { json: flags.json })
+  return withPage(flags, async (page, state) => {
+    const url = pathArg.startsWith('http') ? pathArg : `${state.baseURL}${pathArg.startsWith('/') ? pathArg : `/${pathArg}`}`
+    await page.goto(url, { waitUntil: 'domcontentloaded' })
+    const title = await page.title()
+    return ok({
+      message: `opened ${url}`,
+      url: page.url(),
+      title,
+    }, { json: flags.json })
+  })
+}
+
+function namePattern(name, exact) {
+  if (exact)
+    return name
+  // Allow /regex/ literals
+  if (name.startsWith('/') && name.lastIndexOf('/') > 0) {
+    const last = name.lastIndexOf('/')
+    const body = name.slice(1, last)
+    const flags = name.slice(last + 1)
+    return new RegExp(body, flags)
+  }
+  return new RegExp(name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i')
+}
+
+async function clickCommand(flags) {
+  if (!flags.role || !flags.name) {
+    fail('click requires --role and --name', { json: flags.json })
+  }
+  return withPage(flags, async (page) => {
+    const locator = page.getByRole(flags.role, { name: namePattern(flags.name, flags.exact) })
+    await locator.first().click({ timeout: Number(flags.timeout || 15_000) })
+    return ok({
+      message: `clicked role=${flags.role} name=${flags.name}`,
+      url: page.url(),
+    }, { json: flags.json })
+  })
+}
+
+async function fillCommand(flags) {
+  if (!flags.placeholder || flags.value === undefined) {
+    fail('fill requires --placeholder and --value', { json: flags.json })
+  }
+  return withPage(flags, async (page) => {
+    const input = page.getByPlaceholder(flags.placeholder)
+    await input.fill(String(flags.value), { timeout: Number(flags.timeout || 15_000) })
+    return ok({
+      message: `filled placeholder=${flags.placeholder}`,
+      value: String(flags.value),
+      url: page.url(),
+    }, { json: flags.json })
+  })
+}
+
+async function expectCommand(flags) {
+  if (!flags.role || !flags.name) {
+    fail('expect requires --role and --name', { json: flags.json })
+  }
+  const wantHidden = Boolean(flags.hidden)
+  return withPage(flags, async (page) => {
+    const { expect } = await import('@playwright/test')
+    const locator = page.getByRole(flags.role, { name: namePattern(flags.name, flags.exact) })
+    const timeout = Number(flags.timeout || 15_000)
+    if (wantHidden)
+      await expect(locator.first()).toBeHidden({ timeout })
+    else
+      await expect(locator.first()).toBeVisible({ timeout })
+    return ok({
+      message: `expect ok: role=${flags.role} name=${flags.name} ${wantHidden ? 'hidden' : 'visible'}`,
+      url: page.url(),
+    }, { json: flags.json })
+  })
+}
+
+async function expectUrlCommand(pattern, flags) {
+  if (!pattern)
+    fail('expect-url requires a regex pattern string', { json: flags.json })
+  return withPage(flags, async (page) => {
+    const { expect } = await import('@playwright/test')
+    const re = pattern.startsWith('/') ? namePattern(pattern, false) : new RegExp(pattern)
+    await expect(page).toHaveURL(re, { timeout: Number(flags.timeout || 15_000) })
+    return ok({
+      message: `URL matches ${re}`,
+      url: page.url(),
+    }, { json: flags.json })
+  })
+}
+
+async function snapshotCommand(flags) {
+  return withPage(flags, async (page, state) => {
+    const out = resolveOutPath(state, flags.out, `snapshot-${Date.now()}.txt`)
+    const snapshot = await page.locator('body').ariaSnapshot()
+    writeFileSync(out, `${snapshot}\n`)
+    return ok({
+      message: `wrote snapshot ${out}`,
+      path: out,
+      url: page.url(),
+      preview: snapshot.split('\n').slice(0, 40).join('\n'),
+    }, { json: flags.json })
+  })
+}
+
+async function screenshotCommand(flags) {
+  return withPage(flags, async (page, state) => {
+    const out = resolveOutPath(state, flags.out, `screenshot-${Date.now()}.png`)
+    await page.screenshot({ path: out, fullPage: Boolean(flags.fullPage) })
+    return ok({
+      message: `wrote screenshot ${out}`,
+      path: out,
+      url: page.url(),
+    }, { json: flags.json })
+  })
+}
+
+async function driveFeature(feature, flags) {
+  const recipes = {
+    home: driveHome,
+    blog: driveBlog,
+    videos: driveVideos,
+    'tags-and-search': driveTagsAndSearch,
+  }
+  const fn = recipes[feature]
+  if (!fn) {
+    fail(
+      `unknown feature "${feature}". Mapped features: ${Object.keys(recipes).join(', ')}`,
+      { json: flags.json },
+    )
+  }
+  return withPage(flags, async (page, state) => fn(page, state, flags))
+}
+
+async function driveHome(page, state, flags) {
+  const { expect } = await import('@playwright/test')
+  const evidence = evidenceDirFor(state)
+  await page.goto(`${state.baseURL}/`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })).toBeVisible({ timeout: 20_000 })
+  await expect(page.getByText(/Developer Educator focused on Playwright/i)).toBeVisible()
+  await expect(page.getByRole('region', { name: /Recent Blog Posts/i })).toBeVisible()
+  const shot = join(evidence, 'home-proof.png')
+  const snap = join(evidence, 'home-proof.aria.txt')
+  await page.screenshot({ path: shot, fullPage: false })
+  writeFileSync(snap, `${await page.locator('body').ariaSnapshot()}\n`)
+  writeFileSync(join(evidence, 'home-proof.json'), `${JSON.stringify({
+    feature: 'home',
+    url: page.url(),
+    title: await page.title(),
+    at: new Date().toISOString(),
+    artifacts: [shot, snap],
+  }, null, 2)}\n`)
+  return ok({
+    message: `drove feature home; evidence in ${evidence}`,
+    feature: 'home',
+    url: page.url(),
+    evidenceDir: evidence,
+    artifacts: [shot, snap],
+  }, { json: flags.json })
+}
+
+async function driveBlog(page, state, flags) {
+  const { expect } = await import('@playwright/test')
+  const evidence = evidenceDirFor(state)
+  await page.goto(`${state.baseURL}/blog`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('article').first()).toBeVisible({ timeout: 20_000 })
+  const firstTitle = (await page.getByRole('article').first().getByRole('heading').innerText()).trim()
+  await page.getByRole('article').first().getByRole('link').first().click()
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 20_000 })
+  await expect(page).toHaveURL(/\/blog\/[^/]+\/?$/)
+  const shot = join(evidence, 'blog-proof.png')
+  const snap = join(evidence, 'blog-proof.aria.txt')
+  await page.screenshot({ path: shot })
+  writeFileSync(snap, `${await page.locator('body').ariaSnapshot()}\n`)
+  writeFileSync(join(evidence, 'blog-proof.json'), `${JSON.stringify({
+    feature: 'blog',
+    openedFromListing: firstTitle,
+    url: page.url(),
+    at: new Date().toISOString(),
+    artifacts: [shot, snap],
+  }, null, 2)}\n`)
+  return ok({
+    message: `drove feature blog (opened "${firstTitle}"); evidence in ${evidence}`,
+    feature: 'blog',
+    url: page.url(),
+    evidenceDir: evidence,
+    artifacts: [shot, snap],
+  }, { json: flags.json })
+}
+
+async function driveVideos(page, state, flags) {
+  const { expect } = await import('@playwright/test')
+  const evidence = evidenceDirFor(state)
+  await page.goto(`${state.baseURL}/videos`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('heading', { name: /All Videos|Search Results/i })).toBeVisible({ timeout: 20_000 })
+  await expect.poll(() => page.getByRole('article').count(), { timeout: 20_000 }).toBeGreaterThan(0)
+  const shot = join(evidence, 'videos-proof.png')
+  const snap = join(evidence, 'videos-proof.aria.txt')
+  await page.screenshot({ path: shot })
+  writeFileSync(snap, `${await page.locator('body').ariaSnapshot()}\n`)
+  writeFileSync(join(evidence, 'videos-proof.json'), `${JSON.stringify({
+    feature: 'videos',
+    articleCount: await page.getByRole('article').count(),
+    url: page.url(),
+    at: new Date().toISOString(),
+    artifacts: [shot, snap],
+  }, null, 2)}\n`)
+  return ok({
+    message: `drove feature videos; evidence in ${evidence}`,
+    feature: 'videos',
+    url: page.url(),
+    evidenceDir: evidence,
+    artifacts: [shot, snap],
+  }, { json: flags.json })
+}
+
+async function driveTagsAndSearch(page, state, flags) {
+  const { expect } = await import('@playwright/test')
+  const evidence = evidenceDirFor(state)
+  await page.goto(`${state.baseURL}/blog`, { waitUntil: 'domcontentloaded' })
+  await expect(page.getByRole('article').first()).toBeVisible({ timeout: 20_000 })
+
+  const searchInput = page.getByPlaceholder('Search...')
+  await expect(async () => {
+    await searchInput.fill('playwright')
+    await expect(page.getByRole('heading', { name: /Search Results/i })).toBeVisible()
+  }).toPass({ timeout: 15_000 })
+
+  const searchShot = join(evidence, 'tags-and-search-search.png')
+  await page.screenshot({ path: searchShot })
+
+  await searchInput.clear()
+  await expect(page.getByRole('heading', { name: /Recent Posts/i })).toBeVisible({ timeout: 15_000 })
+
+  const tagLink = page.getByRole('link', { name: '#Playwright' }).first()
+  await expect(async () => {
+    await tagLink.click()
+    await expect(page).toHaveURL(/\/blog\/tags\/playwright\/?$/, { timeout: 2000 })
+  }).toPass({ timeout: 15_000 })
+
+  await expect.poll(
+    () => page.getByRole('article').getByRole('link', { name: /#playwright/i }).count(),
+    { timeout: 15_000 },
+  ).toBeGreaterThan(0)
+
+  const tagShot = join(evidence, 'tags-and-search-tag.png')
+  const snap = join(evidence, 'tags-and-search.aria.txt')
+  await page.screenshot({ path: tagShot })
+  writeFileSync(snap, `${await page.locator('body').ariaSnapshot()}\n`)
+  writeFileSync(join(evidence, 'tags-and-search-proof.json'), `${JSON.stringify({
+    feature: 'tags-and-search',
+    url: page.url(),
+    at: new Date().toISOString(),
+    artifacts: [searchShot, tagShot, snap],
+  }, null, 2)}\n`)
+
+  return ok({
+    message: `drove feature tags-and-search; evidence in ${evidence}`,
+    feature: 'tags-and-search',
+    url: page.url(),
+    evidenceDir: evidence,
+    artifacts: [searchShot, tagShot, snap],
+  }, { json: flags.json })
+}
+
+async function evidenceCommand(sub, flags) {
+  const state = readState()
+  const dir = state ? evidenceDirFor(state) : ARTIFACTS_DIR
+  if (sub === 'path') {
+    return ok({ message: dir, path: dir, artifactsRoot: ARTIFACTS_DIR }, { json: flags.json })
+  }
+  if (sub === 'list' || !sub) {
+    const { readdirSync, statSync } = await import('node:fs')
+    const entries = []
+    if (existsSync(ARTIFACTS_DIR)) {
+      for (const run of readdirSync(ARTIFACTS_DIR)) {
+        const runPath = join(ARTIFACTS_DIR, run)
+        let st
+        try { st = statSync(runPath) }
+        catch { continue }
+        if (!st.isDirectory())
+          continue
+        for (const f of readdirSync(runPath)) {
+          entries.push(join(runPath, f))
+        }
+      }
+    }
+    if (flags.json) {
+      return ok({ artifactsRoot: ARTIFACTS_DIR, evidenceDir: dir, files: entries }, { json: true })
+    }
+    console.log(`artifacts root: ${ARTIFACTS_DIR}`)
+    console.log(`current run:    ${dir}`)
+    if (!entries.length)
+      console.log('(no evidence files yet)')
+    else
+      entries.forEach(f => console.log(f))
+    return
+  }
+  fail(`unknown evidence subcommand "${sub}". Use list or path.`, { json: flags.json })
+}
+
+async function cleanupCommand(flags) {
+  const state = readState()
+  if (!state) {
+    return ok({
+      message: 'nothing to clean up (no state file)',
+      dryRun: Boolean(flags.dryRun),
+    }, { json: flags.json })
+  }
+
+  const actions = []
+  if (state.browser?.owned && state.browser?.cdpPort) {
+    actions.push({ type: 'browser', cdpPort: state.browser.cdpPort, userDataDir: state.browser.userDataDir })
+  }
+  if (state.owned && state.pid) {
+    actions.push({ type: 'nuxt', pid: state.pid, port: state.port })
+  }
+  else if (state.pid && !state.owned) {
+    actions.push({ type: 'skip-nuxt-not-owned', pid: state.pid, port: state.port })
+  }
+
+  if (flags.dryRun) {
+    return ok({
+      message: 'dry-run: would clean up the following (evidence kept)',
+      dryRun: true,
+      actions,
+      evidencePreserved: state.evidenceDir || ARTIFACTS_DIR,
+      statePath: STATE_PATH,
+    }, { json: flags.json })
+  }
+
+  // Close browser via CDP / playwright if possible
+  if (state.browser?.cdpPort) {
+    try {
+      const { chromium } = await loadPlaywright()
+      if (await cdpAlive(state.browser.cdpPort)) {
+        const browser = await chromium.connectOverCDP(`http://${DEFAULT_HOST}:${state.browser.cdpPort}`)
+        await browser.close()
+      }
+    }
+    catch {
+      // fall through
+    }
+    if (state.browser.userDataDir && state.browser.userDataDir.startsWith(STATE_DIR)) {
+      try {
+        rmSync(state.browser.userDataDir, { recursive: true, force: true })
+      }
+      catch { /* ignore */ }
+    }
+  }
+
+  if (state.owned && state.pid && pidAlive(state.pid)) {
+    try {
+      process.kill(-state.pid, 'SIGTERM')
+    }
+    catch {
+      try {
+        process.kill(state.pid, 'SIGTERM')
+      }
+      catch { /* ignore */ }
+    }
+    // brief wait then SIGKILL if needed
+    await new Promise(r => setTimeout(r, 1500))
+    if (pidAlive(state.pid)) {
+      try {
+        process.kill(-state.pid, 'SIGKILL')
+      }
+      catch {
+        try { process.kill(state.pid, 'SIGKILL') }
+        catch { /* ignore */ }
+      }
+    }
+  }
+
+  const evidenceDir = state.evidenceDir || evidenceDirFor(state)
+  clearState()
+
+  // Confirm evidence still exists
+  const evidenceStillThere = existsSync(evidenceDir)
+  return ok({
+    message: `cleanup done; evidence ${evidenceStillThere ? 'preserved' : 'MISSING'} at ${evidenceDir}`,
+    actions,
+    evidencePreserved: evidenceDir,
+    evidenceExists: evidenceStillThere,
+  }, { json: flags.json })
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.flags.help || args._.length === 0)
+    usage(args._.length === 0 ? 1 : 0)
+
+  const [cmd, ...rest] = args._
+  const flags = args.flags
+
+  try {
+    switch (cmd) {
+      case 'launch':
+        await launchCommand(flags)
+        break
+      case 'doctor':
+        await doctorCommand(flags)
+        break
+      case 'info':
+        await infoCommand(flags)
+        break
+      case 'goto':
+        await gotoCommand(rest[0], flags)
+        break
+      case 'click':
+        await clickCommand(flags)
+        break
+      case 'fill':
+        await fillCommand(flags)
+        break
+      case 'expect':
+        await expectCommand(flags)
+        break
+      case 'expect-url':
+        await expectUrlCommand(rest[0], flags)
+        break
+      case 'snapshot':
+        await snapshotCommand(flags)
+        break
+      case 'screenshot':
+        await screenshotCommand(flags)
+        break
+      case 'drive':
+        await driveFeature(rest[0], flags)
+        break
+      case 'evidence':
+        await evidenceCommand(rest[0] || 'list', flags)
+        break
+      case 'cleanup':
+        await cleanupCommand(flags)
+        break
+      default:
+        fail(`unknown command "${cmd}". Pass --help for usage.`, { json: flags.json })
+    }
+  }
+  catch (err) {
+    fail(err?.message || String(err), {
+      json: flags.json,
+      details: flags.json ? { stack: err?.stack } : err?.stack,
+    })
+  }
+}
+
+// Silence unused import warning for accessSync/constants/homedir if tree-shaken oddly
+void accessSync
+void constants
+void homedir
+
+main()

--- a/.cursor/skills/verify-debbie-codes/control-debbie-codes.mjs
+++ b/.cursor/skills/verify-debbie-codes/control-debbie-codes.mjs
@@ -8,16 +8,15 @@
 
 import { spawn } from 'node:child_process'
 import {
-  accessSync,
-  constants,
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs'
-import { createServer } from 'node:http'
-import { homedir, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import process from 'node:process'
@@ -253,17 +252,6 @@ function pidAlive(pid) {
   }
 }
 
-function findFreePort() {
-  return new Promise((resolvePort, reject) => {
-    const server = createServer()
-    server.listen(0, DEFAULT_HOST, () => {
-      const { port } = server.address()
-      server.close(err => (err ? reject(err) : resolvePort(port)))
-    })
-    server.on('error', reject)
-  })
-}
-
 async function waitForReady(url, { timeoutMs = READY_TIMEOUT_MS } = {}) {
   const start = Date.now()
   let lastError = ''
@@ -351,28 +339,22 @@ async function launchCommand(flags) {
   const evidenceDir = join(ARTIFACTS_DIR, runId)
   mkdirSync(evidenceDir, { recursive: true })
   const logPath = join(STATE_DIR, `${runId}-nuxt.log`)
+  // Redirect child stdio to a file so this CLI can exit without keeping
+  // pipe listeners open (which would hang `launch` forever).
+  writeFileSync(logPath, '')
+  const logFd = openSync(logPath, 'a')
 
   const child = spawn('npm', ['run', 'dev', '--', '--host', DEFAULT_HOST, '--port', String(port)], {
     cwd: REPO_ROOT,
     env: { ...process.env, PORT: String(port) },
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['ignore', logFd, logFd],
     detached: true,
   })
 
-  const logFd = { stream: null }
   try {
-    writeFileSync(logPath, '')
+    closeSync(logFd)
   }
   catch { /* ignore */ }
-
-  const appendLog = (chunk) => {
-    try {
-      writeFileSync(logPath, chunk, { flag: 'a' })
-    }
-    catch { /* ignore */ }
-  }
-  child.stdout.on('data', appendLog)
-  child.stderr.on('data', appendLog)
 
   child.unref()
 
@@ -427,7 +409,6 @@ async function doctorCommand(flags) {
   const probe = await httpProbe(`${baseURL}/`)
   const titleMatch = /Debbie/i.test(probe.text || '')
   const ownedAlive = Boolean(state?.owned && state?.pid && pidAlive(state.pid))
-  const browserAlive = Boolean(state?.browser?.cdpPort && await cdpAlive(state.browser.cdpPort))
 
   const report = {
     healthy: Boolean(probe.ok && titleMatch),
@@ -439,8 +420,7 @@ async function doctorCommand(flags) {
     pid: state?.pid || null,
     pidAlive: state?.pid ? pidAlive(state.pid) : false,
     ownedAlive,
-    browserCdp: state?.browser?.cdpPort || null,
-    browserAlive,
+    browserMode: state?.browser?.mode || 'ephemeral-per-command',
     runId: state?.runId || null,
     evidenceDir: state ? evidenceDirFor(state) : ARTIFACTS_DIR,
     checkedAt: new Date().toISOString(),
@@ -461,7 +441,7 @@ async function doctorCommand(flags) {
   console.log(`  httpStatus:  ${report.httpStatus}`)
   console.log(`  identity:    Debbie present`)
   console.log(`  owned:       ${report.ownedProcess} (pid ${report.pid ?? 'n/a'}, alive=${report.pidAlive})`)
-  console.log(`  browserCdp:  ${report.browserCdp ?? 'not started'} (alive=${report.browserAlive})`)
+  console.log(`  browser:     ${report.browserMode} (launched per command)`)
   console.log(`  evidence:    ${report.evidenceDir}`)
   console.log(`  runId:       ${report.runId ?? 'n/a'}`)
 }
@@ -479,11 +459,6 @@ async function infoCommand(flags) {
   }, { json: flags.json })
 }
 
-async function cdpAlive(cdpPort) {
-  const probe = await httpProbe(`http://${DEFAULT_HOST}:${cdpPort}/json/version`, { timeoutMs: 1500 })
-  return probe.ok
-}
-
 async function loadPlaywright() {
   try {
     return await import('playwright')
@@ -496,38 +471,11 @@ async function loadPlaywright() {
   }
 }
 
-async function ensureBrowser(state, flags = {}) {
-  const { chromium } = await loadPlaywright()
-  if (state.browser?.cdpPort && await cdpAlive(state.browser.cdpPort)) {
-    const browser = await chromium.connectOverCDP(`http://${DEFAULT_HOST}:${state.browser.cdpPort}`)
-    const context = browser.contexts()[0] || await browser.newContext({ viewport: { width: 1280, height: 800 } })
-    const page = context.pages()[0] || await context.newPage()
-    return { browser, context, page, state, connected: true }
-  }
-
-  const cdpPort = await findFreePort()
-  const userDataDir = join(STATE_DIR, `browser-${state.runId || 'default'}`)
-  mkdirSync(userDataDir, { recursive: true })
-
-  const context = await chromium.launchPersistentContext(userDataDir, {
-    headless: true,
-    viewport: { width: 1280, height: 800 },
-    args: [`--remote-debugging-port=${cdpPort}`],
-  })
-  const page = context.pages()[0] || await context.newPage()
-  const browser = context.browser()
-
-  state.browser = {
-    cdpPort,
-    userDataDir,
-    startedAt: new Date().toISOString(),
-    owned: true,
-  }
-  writeState(state)
-
-  return { browser, context, page, state, connected: false }
-}
-
+/**
+ * Each CLI invocation gets a fresh headless Chromium and closes it before exit.
+ * That keeps commands agent-friendly (no hung Node process holding CDP) while
+ * the Nuxt server stays up across commands.
+ */
 async function withPage(flags, fn) {
   const state = readState()
   if (!state?.baseURL) {
@@ -538,12 +486,21 @@ async function withPage(flags, fn) {
     fail(`site not reachable at ${state.baseURL}; run doctor / launch`, { json: flags.json })
   }
 
-  const session = await ensureBrowser(state, flags)
+  const { chromium } = await loadPlaywright()
+  const browser = await chromium.launch({ headless: true })
+  const context = await browser.newContext({ viewport: { width: 1280, height: 800 } })
+  const page = await context.newPage()
+  state.browser = {
+    mode: 'ephemeral-per-command',
+    lastUsedAt: new Date().toISOString(),
+  }
+  writeState(state)
+
   try {
-    return await fn(session.page, session.state, session)
+    return await fn(page, state, { browser, context, page })
   }
   finally {
-    // Keep browser alive across commands; cleanup closes it.
+    await browser.close().catch(() => {})
   }
 }
 
@@ -858,8 +815,9 @@ async function cleanupCommand(flags) {
   }
 
   const actions = []
-  if (state.browser?.owned && state.browser?.cdpPort) {
-    actions.push({ type: 'browser', cdpPort: state.browser.cdpPort, userDataDir: state.browser.userDataDir })
+  // Browsers are ephemeral per command; only scratch profiles from older runs may remain.
+  if (state.browser?.userDataDir && state.browser.userDataDir.startsWith(STATE_DIR)) {
+    actions.push({ type: 'browser-profile', userDataDir: state.browser.userDataDir })
   }
   if (state.owned && state.pid) {
     actions.push({ type: 'nuxt', pid: state.pid, port: state.port })
@@ -878,22 +836,18 @@ async function cleanupCommand(flags) {
     }, { json: flags.json })
   }
 
-  // Close browser via CDP / playwright if possible
-  if (state.browser?.cdpPort) {
+  if (state.browser?.userDataDir && state.browser.userDataDir.startsWith(STATE_DIR)) {
     try {
-      const { chromium } = await loadPlaywright()
-      if (await cdpAlive(state.browser.cdpPort)) {
-        const browser = await chromium.connectOverCDP(`http://${DEFAULT_HOST}:${state.browser.cdpPort}`)
-        await browser.close()
-      }
+      rmSync(state.browser.userDataDir, { recursive: true, force: true })
     }
-    catch {
-      // fall through
-    }
-    if (state.browser.userDataDir && state.browser.userDataDir.startsWith(STATE_DIR)) {
-      try {
-        rmSync(state.browser.userDataDir, { recursive: true, force: true })
-      }
+    catch { /* ignore */ }
+  }
+
+  // Remove any leftover browser-* scratch dirs for this run id
+  if (state.runId) {
+    const legacyProfile = join(STATE_DIR, `browser-${state.runId}`)
+    if (existsSync(legacyProfile)) {
+      try { rmSync(legacyProfile, { recursive: true, force: true }) }
       catch { /* ignore */ }
     }
   }
@@ -994,10 +948,5 @@ async function main() {
     })
   }
 }
-
-// Silence unused import warning for accessSync/constants/homedir if tree-shaken oddly
-void accessSync
-void constants
-void homedir
 
 main()

--- a/.cursor/skills/verify-debbie-codes/features/README.md
+++ b/.cursor/skills/verify-debbie-codes/features/README.md
@@ -1,0 +1,46 @@
+# debbie.codes verification map
+
+This directory is the maintained source for verifying user-facing behavior of [debbie.codes](https://debbie.codes). Read the index before driving the app, then use the matching feature file as the recipe.
+
+## Baseline preconditions
+
+- Launch from the repo root: `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs launch` (or `launch --reuse` if `http://127.0.0.1:8000` already serves this site).
+- Require `control-debbie-codes.mjs doctor` to report healthy (HTTP OK + Debbie identity).
+- Prefer the CLI’s owned instance. Do not kill a Nuxt process you did not start.
+- Evidence directory: `.cursor/skills/verify-debbie-codes/artifacts/<run-id>/` (survives `cleanup`).
+- Existing Playwright specs under `tests/` are complementary regression; mapped feature drives below are the agent proof path.
+
+## Driving conventions
+
+- Start every recipe from a doctor-healthy baseline unless preconditions say otherwise.
+- Prefer ARIA roles and accessible names over CSS selectors (matches `tests/*.spec.ts`).
+- Treat every command as literal. Keep quoted names and flags unchanged.
+- Run browser actions through `control-debbie-codes.mjs` (`goto`, `click`, `fill`, `expect`, `drive`, `snapshot`, `screenshot`).
+- On cold loads, retry navigation clicks until the URL changes (Nuxt hydration).
+- Cleanup removes the owned server/browser only; never proof artifacts.
+
+## Proof and skip reporting
+
+- Capture the user action and the resulting state, not only the final screen.
+- UI proof includes an ARIA snapshot and a screenshot with Debbie / page chrome visible.
+- Record the feature ID and entry point with every artifact (`*-proof.json` from `drive`).
+- Report an unreachable path with the attempted command and unmet precondition.
+- Do not report a skipped entry point as verified through a different path.
+
+## Feature entry contract
+
+Each feature file starts with an H1 title and one paragraph describing the user-visible behavior. It then uses exactly four H2 sections in this order.
+
+1. `Sub-features` lists short IDs with one line for each behavior.
+2. `How to get to it (user POV)` lists every user entry point.
+3. `Driving it with control-debbie-codes` starts with `Preconditions:` and uses labeled bullets that pair each user action with an exact command and observable result.
+4. `Gotchas` lists traps that can waste or invalidate a verification run.
+
+Keep implementation details out of the map. Name only user paths, stable handles, required state, commands, and observable proof.
+
+## Features (sweep order)
+
+1. [Home](./home.md) — hero identity and recent content regions.
+2. [Blog](./blog.md) — listing, open article, back/prev/next chrome.
+3. [Videos](./videos.md) — videos index and topic tags.
+4. [Tags and search](./tags-and-search.md) — blog search box and tag filter pages.

--- a/.cursor/skills/verify-debbie-codes/features/blog.md
+++ b/.cursor/skills/verify-debbie-codes/features/blog.md
@@ -1,0 +1,34 @@
+# Blog
+
+Blog lets a visitor browse recent posts, open an article to read it, and move between posts with back / previous / next links.
+
+## Sub-features
+
+- `blog-list` shows articles on `/blog`.
+- `blog-open` opens one article from the listing into `/blog/<slug>`.
+- `blog-chrome` shows back-to-blog and (when present) previous/next post links on an article.
+- `blog-pagination` reaches older posts via `/blog/page/<n>` when used.
+
+## How to get to it (user POV)
+
+- Choose `Blog` in the header (or footer) navigation.
+- Open `/blog` directly.
+- Follow a “Recent Blog Posts” link or card from the home page.
+
+## Driving it with control-debbie-codes
+
+Preconditions:
+
+- Doctor healthy.
+- Content collections include at least one published blog post (true for this repo’s `content/blog`).
+
+- **Open listing.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs goto /blog` then `expect --role article --name "/.+/"` is not required; instead wait via the recipe or assert the first article: after `goto`, use `drive blog` or click the first article link.
+- **Nav entry.** From home: `click --role link --name Blog` then `expect-url "/\\/blog\\/?$/"` (retry click if URL unchanged — hydration).
+- **Open article.** Prefer the one-shot recipe: `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive blog --json`. Observable end state: URL matches `/blog/<slug>`, an H1 is visible, and evidence files `blog-proof.png` / `blog-proof.aria.txt` / `blog-proof.json` exist.
+- **Proof.** Artifacts show the article heading and a `/blog/` URL that is not the listing alone.
+
+## Gotchas
+
+- First click after a cold load may no-op before Nuxt hydration; retry until the URL changes (see `clickUntilUrl` in `tests/blog.spec.ts`).
+- Article cards wrap title + description in a link; when reading a title for search, use the heading text inside the article, not the whole link name.
+- Prev/next link names include the adjacent post title; assert `href` or visible name after navigation settles.

--- a/.cursor/skills/verify-debbie-codes/features/home.md
+++ b/.cursor/skills/verify-debbie-codes/features/home.md
@@ -1,0 +1,35 @@
+# Home
+
+The home page introduces Debbie O'Brien and surfaces recent videos, podcasts, and blog posts so a visitor can recognize the site and jump into content.
+
+## Sub-features
+
+- `home-identity` shows the H1 name and educator tagline.
+- `home-recent-blog` lists recent blog posts in a named region.
+- `home-recent-podcasts` lists recent podcasts in a named region.
+- `home-nav` reaches About, Videos, Podcasts, Courses, and Blog from the header.
+
+## How to get to it (user POV)
+
+- Open `/` directly.
+- Choose the site logo / name link from any page.
+- Land from an external link to `https://debbie.codes/`.
+
+## Driving it with control-debbie-codes
+
+Preconditions:
+
+- `control-debbie-codes.mjs doctor` reports healthy at `http://127.0.0.1:8000` (or the launched `--port`).
+- Desktop viewport (default CLI viewport 1280×800); mobile uses a hamburger (`open menu`) not covered by the default recipe.
+
+- **Open home.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs goto /`. The document title mentions Debbie and the URL path is `/`.
+- **Identity.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs expect --role heading --name "/Debbie O'Brien/i"`. The level-1 heading is visible with the educator tagline text nearby.
+- **Recent blog region.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs expect --role region --name "/Recent Blog Posts/i"`. The region is visible.
+- **One-shot recipe.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive home --json`. Exit `0`; evidence files `home-proof.png`, `home-proof.aria.txt`, and `home-proof.json` appear under the run’s artifacts directory.
+- **Proof.** Screenshot and ARIA snapshot show the Debbie heading and at least one recent-content region.
+
+## Gotchas
+
+- Featured Posts / article-count assertions in older specs are partially `fixme` after redesign; prefer regions and the H1, not obsolete featured-post counts.
+- Dark/light color mode changes chrome colors; assert roles/names, not pixel colors.
+- Logo accessible name is duplicated text (`Debbie O'Brien Debbie O'Brien`) in specs — match carefully if clicking the logo.

--- a/.cursor/skills/verify-debbie-codes/features/tags-and-search.md
+++ b/.cursor/skills/verify-debbie-codes/features/tags-and-search.md
@@ -1,0 +1,40 @@
+# Tags and search
+
+Tags and search let a visitor narrow blog posts by typing in the search box or by choosing a topic chip, then recognize empty results and clear back to the full list.
+
+## Sub-features
+
+- `search-open` focuses the blog search field on `/blog`.
+- `search-match` filters articles to title/description/tag matches and shows `Search Results`.
+- `search-empty` shows `Search Results (0)` with no articles for a nonsense query.
+- `search-clear` clears the field and restores `Recent Posts`.
+- `tag-filter` opens `/blog/tags/<tag>` from a `#Tag` chip and keeps matching tagged articles.
+
+## How to get to it (user POV)
+
+- On `/blog`, use the `Search...` field near the top of the listing.
+- On `/blog`, choose a Browse-by-topic chip such as `#Playwright`.
+- Open `/blog/tags/playwright` (or another tag slug) directly.
+
+## Driving it with control-debbie-codes
+
+Preconditions:
+
+- Doctor healthy.
+- Desktop viewport (search/tag filter UI is asserted mainly for non-mobile in `tests/blog-search.spec.ts` and `tests/blog-filters.spec.ts`).
+- At least one post tagged `playwright` exists in content.
+
+- **Open blog.** `goto /blog` and wait until an `article` is visible.
+- **Search match.** `fill --placeholder "Search..." --value playwright` then `expect --role heading --name "/Search Results/i"`. At least one article remains for a known term.
+- **Empty search.** `fill --placeholder "Search..." --value xyz123nonexistent` then `expect --role heading --name "/Search Results \\(0\\)/i"`.
+- **Clear.** Clear the input (fill with empty via recipe or re-`fill` after clear in a custom script); heading returns to `Recent Posts`.
+- **Tag chip.** `click --role link --name "#Playwright"` then `expect-url "/\\/blog\\/tags\\/playwright\\/?$/"`. Articles expose a `#playwright` tag link.
+- **One-shot recipe.** `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive tags-and-search --json`. Evidence includes search and tag screenshots plus `tags-and-search-proof.json`.
+- **Proof.** Artifacts show both a populated search-results heading state and a tag URL with matching articles — not only the `/blog` listing.
+
+## Gotchas
+
+- Search activates after Vue hydration; retry fill until the `Search Results` heading appears (`searchFor` helper in `tests/blog-search.spec.ts`).
+- Tag accessible names use display casing (`#Playwright`, `#AI`) while the path slug is lowercase (`playwright`, `ai`).
+- Clearing search is part of the proof that search did not permanently mutate content — always restore or assert `Recent Posts` after a match run when composing manually.
+- Videos also reuse `Search...`; this feature file’s recipe targets **blog** tags/search unless you explicitly start on `/videos`.

--- a/.cursor/skills/verify-debbie-codes/features/videos.md
+++ b/.cursor/skills/verify-debbie-codes/features/videos.md
@@ -1,0 +1,34 @@
+# Videos
+
+Videos lists Debbie’s video content, lets a visitor browse by topic tag, and search within the videos collection.
+
+## Sub-features
+
+- `videos-list` shows the All Videos heading and article cards on `/videos`.
+- `videos-tag` filters via `#topic` chips to `/videos/tags/<slug>`.
+- `videos-search` filters the grid via the shared search placeholder `Search...`.
+
+## How to get to it (user POV)
+
+- Choose `Videos` in the header or footer navigation.
+- Open `/videos` directly.
+- Follow “Recent Videos” from the home page.
+
+## Driving it with control-debbie-codes
+
+Preconditions:
+
+- Doctor healthy.
+- Desktop viewport for tag chips / search (mobile layout differs; existing specs often skip mobile for filters).
+
+- **Open videos.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs goto /videos`.
+- **List visible.** Run `expect --role heading --name "/All Videos|Search Results/i"`. At least one `article` appears (poll if hydrating).
+- **One-shot recipe.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive videos --json`. Evidence: `videos-proof.png`, `videos-proof.aria.txt`, `videos-proof.json` with `articleCount > 0`.
+- **Tag (manual compose).** `click --role link --name "/#playwright/i"` then `expect-url "/\\/videos\\/tags\\/playwright/"`. Articles remain present.
+- **Proof.** Screenshot shows the videos index or a tag page with video cards; JSON records a positive article count.
+
+## Gotchas
+
+- Tag labels use a `#` prefix and may include spaces in the accessible name (e.g. `#conference talk`) while the URL slug uses hyphens.
+- Home “Recent Videos” markup changed across redesigns; do not require `article` children inside that home region — verify the dedicated `/videos` page instead.
+- Search shares `BlogSearch` with placeholder `Search...`; searching flips the heading to `Search Results (N)`.

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,10 @@ playwright-report/
 /playwright/.cache/
 .playwright-cli/
 
+# Verification skill evidence (keep directory via .gitkeep)
+.cursor/skills/verify-debbie-codes/artifacts/**
+!.cursor/skills/verify-debbie-codes/artifacts/.gitkeep
+
 # Build output
 .output/
 blob-report/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a pstack-style project-local verification skill so agents can drive the live debbie.codes Nuxt site the way a user does and capture proof.

## What’s included

- `.cursor/skills/verify-debbie-codes/SKILL.md` — Launch / Doctor / Drive / Evidence / Cleanup / Helpers grounded in this repo
- Feature map under `features/` — home, blog, videos, tags-and-search
- `control-debbie-codes.mjs` — agent-friendly CLI wrapping the existing Playwright stack (no second browser harness)
- Evidence dir under `artifacts/` (gitignored contents; survives cleanup)

## Out of scope

- No site content, blog posts, or public copy changes
- Leaves `.agents/skills/add-content` and `.agents/skills/playwright-cli` untouched

## Proof (ran once end-to-end)

```text
launch → doctor → drive home → evidence list → cleanup --dry-run → cleanup
```

- `doctor`: healthy, Debbie identity present
- `drive home`: wrote `home-proof.png`, `home-proof.aria.txt`, `home-proof.json`
- `cleanup`: stopped owned Nuxt; **evidence still on disk** (`evidenceExists: true`)
- Relaunch sanity: `launch` exits in ~6s (no hung stdio/CDP)

![Home feature proof screenshot](https://cursor.com/artifacts/c/art-bbc0f86a-33ce-47c3-b93f-0aa40d9bda6c)

## CI note

An earlier Netlify-preview Playwright/Endform failure was unrelated to this scaffolding: merge-commit tests expected About a11y markup from `#605` while the preview still served the pre-`#605` branch tip. Branch now includes `main` (`#605`); preview CI re-running.

## Maintenance

Point follow-ups at `/maintain-verification-skill` when that pstack skill is available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b395acbb-e111-4655-98bf-8abbf70df3c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b395acbb-e111-4655-98bf-8abbf70df3c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

