### PR TITLE
content: drop the Zephyr Cloud link from About

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -4,7 +4,7 @@ title: About
 
 With over 15 years in frontend development I have led teams, taught workshops, and spent a lot of time on performance and testing. I help people work with AI agents. I build and use multi-agent workflows every day.
 
-I was a Platform Engineer in Applied AI at [Zephyr Cloud](https://zephyr-cloud.io) on a contract that has now ended. Before that I was a Senior Staff Developer Relations Engineer, Applied AI at Block, and a Principal Technical Program Manager at Microsoft, focused on Playwright, Playwright MCP, and Playwright Agents.
+I was a Platform Engineer in Applied AI at Zephyr Cloud on a contract that has now ended. Before that I was a Senior Staff Developer Relations Engineer, Applied AI at Block, and a Principal Technical Program Manager at Microsoft, focused on Playwright, Playwright MCP, and Playwright Agents.
 
 I am a Google Developer Expert in web technologies, and a former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star. I still love Vue and Nuxt, and I spend most of my teaching time on Playwright and how AI fits into modern developer workflows. I speak at meetups and conferences around the world, including Antarctica.
 

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -30,6 +30,7 @@ test.describe('About Page', () => {
       await expect(page.locator('.prose').getByText(/I help people work with AI agents/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/I build and use multi-agent workflows every day/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Zephyr Cloud/)).toBeVisible();
+      await expect(page.getByRole('link', { name: /Zephyr/i })).toHaveCount(0);
       await expect(page.locator('.prose').getByText(/Senior Staff Developer Relations Engineer, Applied AI at Block/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Principal Technical Program Manager at Microsoft, focused on Playwright/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Google Developer Expert in web technologies/)).toBeVisible();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the `zephyr-cloud.io` link from the About bio. The ended-contract sentence stays as plain text.

The About Playwright spec still checks that Zephyr Cloud is mentioned, and now also asserts there is no Zephyr link on the page.

Rebased onto `main` after #603 merged. Preview/Endform had been running the new videos pagination specs against a Netlify preview that still listed every video (135 articles instead of 24).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f3902b-c3c7-41e0-9f1a-c4753d2a0af1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

