### PR TITLE
Temporarily disable Endform (free-tier limits)

### DIFF
--- a/.github/workflows/endform-tests.yml
+++ b/.github/workflows/endform-tests.yml
@@ -1,5 +1,7 @@
-name: Endform on Netlify Preview
-
+# TEMPORARILY DISABLED: Endform removed due to free-tier limits; restore later.
+# To restore: re-enable the `on:` triggers below, remove `if: false` from jobs,
+# and re-add the `endform` devDependency + `test:endform` script (see ENDFORM.md).
+#
 # Runs the Playwright suite on Endform's cloud runners against the Netlify
 # deploy preview for a PR — the parallel counterpart to preview-tests.yml so we
 # can compare wall-clock time and flaky-test analytics against GitHub Actions.
@@ -14,8 +16,8 @@ name: Endform on Netlify Preview
 # pull_request (not status) means the PR branch's own workflow file runs.
 
 on:
-  pull_request:
-    branches: [main, master]
+  # pull_request:
+  #   branches: [main, master]
   workflow_dispatch:
     inputs:
       base_url:
@@ -30,6 +32,7 @@ permissions:
 
 jobs:
   resolve-preview:
+    if: false # TEMPORARILY DISABLED: Endform free-tier exhausted; restore later
     runs-on: ubuntu-latest
     outputs:
       base_url: ${{ steps.resolve.outputs.base_url }}
@@ -96,6 +99,7 @@ jobs:
           exit 1
 
   endform-tests:
+    if: false # TEMPORARILY DISABLED: Endform free-tier exhausted; restore later
     needs: resolve-preview
     timeout-minutes: 30
     runs-on: ubuntu-latest

--- a/ENDFORM.md
+++ b/ENDFORM.md
@@ -1,5 +1,7 @@
 # Endform POC
 
+> **TEMPORARILY DISABLED:** Endform was removed due to free-tier limits; restore later (re-add `endform` dep + `test:endform` script, and re-enable `.github/workflows/endform-tests.yml`).
+
 Running the Playwright suite on [Endform](https://endform.dev) — a managed,
 distributed Playwright runner that fans every test out to its own isolated
 cloud VM — so we can compare wall-clock time and flaky-test analytics against

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "debbie-codes-poc",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -21,7 +21,6 @@
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^24.7.1",
         "dotenv": "^17.2.3",
-        "endform": "^0.72.0",
         "eslint": "^9.22.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.3",
@@ -8382,74 +8381,6 @@
       "dependencies": {
         "once": "^1.4.0"
       }
-    },
-    "node_modules/endform": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/endform/-/endform-0.72.0.tgz",
-      "integrity": "sha512-xwUkWHNmdI/vKKbzmwO5MUodKKppTFc0zNXEHzBVpdOWic21HaIVFWc59v+GBldmY3H3AjJr68AoNVpLd1rJtg==",
-      "dev": true,
-      "license": "UNLICENSED",
-      "bin": {
-        "endform": "bin/endform"
-      },
-      "optionalDependencies": {
-        "endform-darwin-arm64": "0.72.0",
-        "endform-darwin-x86": "0.72.0",
-        "endform-linux-arm64": "0.72.0",
-        "endform-linux-x86": "0.72.0"
-      }
-    },
-    "node_modules/endform-darwin-arm64": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/endform-darwin-arm64/-/endform-darwin-arm64-0.72.0.tgz",
-      "integrity": "sha512-EVyX0Hu+uvPpWxqgNtfvrIKtc/ClvLpHaWFWzdd39uCB2DsBQ60xdn2Rk9NBjDo7ODUi24ktxMLsPnZKTFiAgg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/endform-darwin-x86": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/endform-darwin-x86/-/endform-darwin-x86-0.72.0.tgz",
-      "integrity": "sha512-PNSeiz418ABoBO/HFS9M5KlyaNHoxTp07jaNDDGIhuiSDRKQUH3yH9TcpkcvEFinXHkL9d4DzPpVXkva4wr3Xw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/endform-linux-arm64": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/endform-linux-arm64/-/endform-linux-arm64-0.72.0.tgz",
-      "integrity": "sha512-0yNzar6iLMhTScedgcPMyd615OhGpNeVlNpEqVl3WaCJTjT9cVuY3UtRpFv/veFI+vDaw0DIl4+bSYDM96167A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/endform-linux-x86": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/endform-linux-x86/-/endform-linux-x86-0.72.0.tgz",
-      "integrity": "sha512-X30gs61WCM+m+pD0r/HscV6q5pm20zA51bddZyfLVgkw2kszczL6PzzgUV6YL7fRyB63qNUF989gYbN+ZOh8lg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/engine.io-client": {
       "version": "6.6.3",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "playwright test",
-    "test:endform": "endform test"
+    "test": "playwright test"
   },
   "dependencies": {
     "better-sqlite3": "^12.4.1",
@@ -31,7 +30,6 @@
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^24.7.1",
     "dotenv": "^17.2.3",
-    "endform": "^0.72.0",
     "eslint": "^9.22.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.3",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Temporarily remove Endform from CI/local scripts so the team can keep iterating — Debbie is out of free Endform usage. **We will add it back later.**

- Removed `endform` devDependency and `test:endform` npm script
- Disabled `.github/workflows/endform-tests.yml` (no `pull_request` trigger; jobs gated with `if: false`)
- Left `ENDFORM.md` and workflow file in place for an easy restore

**Restore later:** re-add the `endform` dep + `test:endform` script, re-enable the `pull_request` trigger and remove `if: false` from jobs in `endform-tests.yml` (see `ENDFORM.md`).

## Proof

- No workflow other than the disabled `endform-tests.yml` references Endform; PR trigger is commented out and jobs use `if: false`
- `package.json` / lockfile no longer include `endform` or `test:endform`
- Husky/lint-staged do not call Endform
- `npm test -- tests/seed.spec.ts` passed (Playwright path intact)

## Test plan

- [x] Confirm no workflow on push/PR invokes `endform`
- [x] Confirm `package.json` / lockfile no longer depend on `endform`
- [x] Confirm `npm test` (Playwright) still works
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-085d2937-03c5-49e3-b76d-bed1e9b8d137?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-085d2937-03c5-49e3-b76d-bed1e9b8d137&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

