### PR TITLE
About bio Option B: Independent Developer Educator lead

### DIFF
--- a/.cursor/skills/verify-debbie-codes/features/about.md
+++ b/.cursor/skills/verify-debbie-codes/features/about.md
@@ -26,6 +26,6 @@ Preconditions:
 
 ## Gotchas
 
-- Bio copy is past-tense on employment (Zephyr / Block). Assert structure and current copy, not a remembered sentence from an older PR.
+- Bio leads with Independent Developer Educator + AI agents (Microsoft TPM / Playwright as track record). No Zephyr in the About bio. Assert structure and current copy, not a remembered sentence from an older PR.
 - Award cards are `article` items with visible `About {name}` text. Count roles from the page you launched.
 - Bio and awards both mention Google Developer Expert. Scope GDE sentences to `.prose` when the text appears twice.

--- a/content/about.md
+++ b/content/about.md
@@ -2,9 +2,7 @@
 title: About
 ---
 
-With over 15 years in frontend development I have led teams, taught workshops, and spent a lot of time on performance and testing. I help people work with AI agents. I build and use multi-agent workflows every day.
-
-I was a Platform Engineer in Applied AI at Zephyr Cloud on a contract that has now ended. Before that I was a Senior Staff Developer Relations Engineer, Applied AI at Block, and a Principal Technical Program Manager at Microsoft, focused on Playwright, Playwright MCP, and Playwright Agents.
+I help developers work with AI agents — testing, shipping, and teaching the craft. Former Microsoft TPM on Playwright, GDE, now building and using multi-agent workflows every day as an Independent Developer Educator.
 
 I am a Google Developer Expert in web technologies, and a former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star. I still love Vue and Nuxt, and I spend most of my teaching time on Playwright and how AI fits into modern developer workflows. I speak at meetups and conferences around the world, including Antarctica.
 

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -19,20 +19,18 @@ test.describe('About Page', () => {
 
   test('About page - Displays biographical content', async ({ page }) => {
     await test.step('Verify professional background paragraph', async () => {
-      const bioParagraph = page.getByText('With over 15 years in frontend development');
-      await expect(bioParagraph).toBeVisible();
-      await expect(bioParagraph).toContainText('performance and testing');
-      await expect(bioParagraph).toContainText('AI agents');
+      const bio = page.locator('.prose');
+      await expect(bio.getByText(/Independent Developer Educator/)).toBeVisible();
+      await expect(bio.getByText(/AI agents/)).toBeVisible();
+      await expect(bio.getByText(/Former Microsoft TPM on Playwright/)).toBeVisible();
+      await expect(bio.getByText(/\bGDE\b/)).toBeVisible();
     });
 
     await test.step('Verify role and achievements', async () => {
       // Bio + awards section both mention GDE — scope to the bio content renderer
-      await expect(page.locator('.prose').getByText(/I help people work with AI agents/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/I build and use multi-agent workflows every day/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/Zephyr Cloud/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/multi-agent workflows every day/)).toBeVisible();
+      await expect(page.locator('.prose').getByText(/Zephyr/i)).toHaveCount(0);
       await expect(page.getByRole('link', { name: /Zephyr/i })).toHaveCount(0);
-      await expect(page.locator('.prose').getByText(/Senior Staff Developer Relations Engineer, Applied AI at Block/)).toBeVisible();
-      await expect(page.locator('.prose').getByText(/Principal Technical Program Manager at Microsoft, focused on Playwright/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/Google Developer Expert in web technologies/)).toBeVisible();
       await expect(page.locator('.prose').getByText(/former Microsoft MVP, Cloudinary Media Developer Expert, and GitHub Star/)).toBeVisible();
     });

--- a/tests/verify-about-page-biography.spec.ts
+++ b/tests/verify-about-page-biography.spec.ts
@@ -12,7 +12,9 @@ test.describe('About Page Content', () => {
     await expect(page.getByRole('heading', { name: 'I\'m Debbie O\'Brien' })).toBeVisible();
 
     // 3. Read the biography sections
-    await expect(page.getByText('With over 15 years in frontend development')).toBeVisible();
+    await expect(page.locator('.prose').getByText(/Independent Developer Educator/)).toBeVisible();
+    await expect(page.locator('.prose').getByText(/AI agents/)).toBeVisible();
+    await expect(page.locator('.prose').getByText(/Former Microsoft TPM on Playwright/)).toBeVisible();
     await expect(page.getByRole('link', { name: 'YouTube Channel' })).toBeVisible();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rewrites the About biography in `content/about.md` to approved Option B: lead with Independent Developer Educator + AI agents, with Microsoft TPM / Playwright as track record.
- Removes Zephyr from the About bio entirely (no Zephyr text or link).
- Updates About Playwright specs and the verify-debbie-codes About feature note to match the new copy.

## Test plan
- [x] `npx playwright test tests/about-page.spec.ts tests/verify-about-page-biography.spec.ts` — **6 passed** locally
- [ ] Spot-check `/about` in the browser: Option B lead visible, no Zephyr in bio, personal close / YouTube / email intact, awards unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de508572-e006-4f78-8358-01d959f93275?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de508572-e006-4f78-8358-01d959f93275&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

