### PR TITLE
fix: site scout hygiene (typos, speaking link a11y, Nuxt team URL)

### DIFF
--- a/.cursor/skills/verify-debbie-codes/features/about.md
+++ b/.cursor/skills/verify-debbie-codes/features/about.md
@@ -20,12 +20,12 @@ Preconditions:
 - `control-debbie-codes.mjs doctor` reports healthy.
 
 - **Open about.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs goto /about`. The h1 matches `/I'm Debbie O'Brien/i`.
-- **Awards.** The h2 `Awards & Achievements` is visible. `main article` count is 9.
+- **Awards.** The h2 `Awards & Achievements` is visible. `main article` count is 8.
 - **One-shot recipe.** Run `node .cursor/skills/verify-debbie-codes/control-debbie-codes.mjs drive about --json`. Evidence: `about-proof.png`, `about-proof.aria.txt`, `about-proof.json`.
 - **Isolated driver.** `.cursor/skills/verify-debbie-codes/bin/verify drive about` is the same path on port 8010.
 
 ## Gotchas
 
 - Bio leads with Independent Developer Educator + AI agents (Microsoft TPM / Playwright as track record). No Zephyr in the About bio. Assert structure and current copy, not a remembered sentence from an older PR.
-- Award cards are `article` items with visible `About {name}` text. Count roles from the page you launched.
+- Most award cards are `article` items with visible `About {name}` links; Nuxt Ambassador is text-only (no href). Count roles from the page you launched.
 - Bio and awards both mention Google Developer Expert. Scope GDE sentences to `.prose` when the text appears twice.

--- a/.cursor/skills/verify-debbie-codes/features/about.md
+++ b/.cursor/skills/verify-debbie-codes/features/about.md
@@ -6,7 +6,7 @@ About is the biography and the awards grid.
 
 - `about-hero` shows the About label and `I'm Debbie O'Brien` heading.
 - `about-bio` renders the markdown biography, including the YouTube Channel link.
-- `about-awards` lists nine award cards under Awards & Achievements.
+- `about-awards` lists eight award cards under Awards & Achievements (Nuxt Ambassador is text-only).
 
 ## How to get to it (user POV)
 

--- a/components/CreativeHero.vue
+++ b/components/CreativeHero.vue
@@ -84,17 +84,12 @@
           <span>GitHub Star Alumni</span>
         </a>
 
-        <a
-          href="https://nuxt.com/team"
-          target="_blank"
-          rel="nofollow noopener noreferrer"
-          class="badge-link"
-        >
+        <span class="badge-link">
           <svg class="w-4 h-4 text-primary shrink-0" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 2L9.5 8.5L3 9.5L7.5 14L6.5 20.5L12 17.5L17.5 20.5L16.5 14L21 9.5L14.5 8.5L12 2Z" />
           </svg>
           <span>Nuxt Ambassador</span>
-        </a>
+        </span>
       </div>
     </div>
   </section>

--- a/components/CreativeHero.vue
+++ b/components/CreativeHero.vue
@@ -85,7 +85,7 @@
         </a>
 
         <a
-          href="https://nuxtjs.org/teams/"
+          href="https://nuxt.com/team"
           target="_blank"
           rel="nofollow noopener noreferrer"
           class="badge-link"

--- a/content/videos/playwright-mcp-servers-explained-automation-and-testing.md
+++ b/content/videos/playwright-mcp-servers-explained-automation-and-testing.md
@@ -1,5 +1,5 @@
 ---
-title: "Playwright MCP Severs Explained: Automation and Testing"
+title: "Playwright MCP Servers Explained: Automation and Testing"
 date: 2025-11-17
 description: "Model Context Protocol (MCP) meets Playwright! In this video, we explore how MCP servers bridge the gap between AI and browser automation, enabling intelligent testing workflows. Learn how to set up Playwright MCP servers, understand their architecture, and see real-world examples of AI-powered testing in action."
 video: U5Hsa6s2EqE

--- a/content/videos/testing-web-applications-playwright-nordicjs.md
+++ b/content/videos/testing-web-applications-playwright-nordicjs.md
@@ -4,5 +4,5 @@ date: 2022-10-07
 description: Let me introduce you to Playwright - Reliable end-to-end cross browser testing for modern web apps, by Microsoft and fully open source. Playwright’s codegen generates tests for you in JavaScript, TypeScript, Dot Net, Java or Python. Now you really have no excuses. It\’s time to play your tests wright.
 video: Cjg545ew1q8
 tags: [conference-talk, testing, playwright]
-conference: NordicJS, Sweeden
+conference: NordicJS, Sweden
 ---

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -3,7 +3,7 @@ const { data: about } = await useAsyncData('about', () => queryCollection('about
 
 const title = ref('About Debbie and her experience as a developer')
 const description = ref(
-  'Google Developer Expert, former Microsoft MVP, GitHub Star Alumni, Cloudinary MDE, Nuxt Ambassador, Auth0 Ambassador',
+  'Google Developer Expert, former Microsoft MVP, GitHub Star Alumni, Cloudinary MDE, Nuxt Ambassador',
 )
 const awards = ref([
   {
@@ -26,7 +26,6 @@ const awards = ref([
   },
   {
     name: 'Nuxt Ambassador',
-    url: 'https://nuxt.com/team',
     about:
       'Formerly Developer Relations at Nuxt, now a Nuxt Ambassador supporting the community through talks, content, and advocacy for Nuxt and the Vue ecosystem.',
   },
@@ -35,12 +34,6 @@ const awards = ref([
     url: 'https://cloudinary.com/mde',
     about:
       'A Cloudinary Media Developer Expert helping developers use media technology effectively in web and mobile apps.',
-  },
-  {
-    name: 'Auth0 Ambassador',
-    url: 'https://community.auth0.com/',
-    about:
-      'An Auth0 Ambassador focused on authentication, security, and identity — through meetups, conferences, and community education.',
   },
   {
     name: 'Microsoft Certified',
@@ -140,6 +133,7 @@ useHead({
             >
               <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3 group-hover:text-primary transition-colors">
                 <a
+                  v-if="award.url"
                   :href="award.url"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -148,6 +142,9 @@ useHead({
                 >
                   {{ award.name }}
                 </a>
+                <template v-else>
+                  {{ award.name }}
+                </template>
               </h3>
 
               <p class="text-gray-600 dark:text-gray-300 leading-relaxed text-sm mb-5">
@@ -155,6 +152,7 @@ useHead({
               </p>
 
               <a
+                v-if="award.url"
                 :href="award.url"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -26,7 +26,7 @@ const awards = ref([
   },
   {
     name: 'Nuxt Ambassador',
-    url: 'https://nuxtjs.org/teams/',
+    url: 'https://nuxt.com/team',
     about:
       'Formerly Developer Relations at Nuxt, now a Nuxt Ambassador supporting the community through talks, content, and advocacy for Nuxt and the Vue ecosystem.',
   },

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -38,7 +38,7 @@ const awards = ref([
   },
   {
     name: 'Auth0 Ambassador',
-    url: 'https://auth0.com/ambassador-program/',
+    url: 'https://community.auth0.com/',
     about:
       'An Auth0 Ambassador focused on authentication, security, and identity — through meetups, conferences, and community education.',
   },

--- a/pages/speaking.vue
+++ b/pages/speaking.vue
@@ -6,6 +6,7 @@ const upcoming = [
     place: 'Zurich, Switzerland',
     title: 'Bug Report In, Pull Request Out: Agentic CI with Playwright',
     url: 'https://conf.zurichjs.com/speakers/debbie-o-brien',
+    linkLabel: 'ZurichJS speaker page',
   },
   {
     event: 'Infobip Shift',
@@ -13,6 +14,7 @@ const upcoming = [
     place: 'Zadar, Croatia',
     title: 'The Agentic Developer: Orchestrating AI Workflows With Skills and MCPs',
     url: 'https://shift.infobip.com/agenda/',
+    linkLabel: 'Infobip Shift agenda',
   },
 ]
 
@@ -62,7 +64,7 @@ useHead({
           rel="noopener noreferrer"
           class="text-primary font-medium hover:underline"
         >
-          Event site
+          {{ talk.linkLabel }}
         </a>
       </li>
     </ul>

--- a/specs/test-plan.md
+++ b/specs/test-plan.md
@@ -785,7 +785,7 @@
 - Google GDE link navigates to me.developers.google.com
 - Microsoft MVP link navigates to mvp.microsoft.com
 - GitHub Star Alumni link navigates to stars.github.com/alumni/
-- Nuxt Ambassador link navigates to nuxtjs.org/teams/
+- Nuxt Ambassador link navigates to nuxt.com/team
 - All links open in new tab or current tab
 
 ---

--- a/specs/test-plan.md
+++ b/specs/test-plan.md
@@ -43,8 +43,8 @@
 - Google GDE badge link is present
 - Former Microsoft MVP badge link is present
 - GitHub Star Alumni badge link is present
-- Nuxt Ambassador badge link is present
-- All badge links are clickable and navigate to external pages
+- Nuxt Ambassador badge text is present (not linked)
+- Linked badges are clickable and navigate to external pages
 
 #### 1.3 Verify Featured Posts Section
 **Steps:**
@@ -217,16 +217,15 @@
   1. GitHub Star Alumni
   2. Google Developer Expert
   3. Former Microsoft Most Valuable Professional
-  4. Media Developer Expert
-  5. Auth0 Ambassador
+  4. Nuxt Ambassador (text only; no external link)
+  5. Media Developer Expert
   6. Microsoft Certified
   7. Bachelor's Level Diploma
   8. Full Stack JavaScript Tech Degree
-- Each card contains:
-  - Image/logo
+- Linked cards contain:
   - Heading with "Learn more" text
   - Description paragraph
-  - "Learn More" link to external site
+  - "About {name}" link to external site
 
 ---
 
@@ -763,17 +762,17 @@
 3. Click on "Learn More" links
 
 **Expected Results:**
-- Each award card has a "Learn More" link
+- Linked award cards have an "About {name}" link
 - Links navigate to external pages:
   - GitHub Stars Alumni page
   - Google Developer Expert profile
   - Microsoft MVP profile
   - Cloudinary MDE page
-  - Auth0 Ambassador program
   - Microsoft certification page
   - OpenClassrooms
   - Team Treehouse
-- All links open correctly (new tab or current tab)
+- Nuxt Ambassador has no external link (no live page that names Debbie)
+- Linked awards open correctly (new tab or current tab)
 
 #### 9.4 Verify External Links on Home Page
 **Steps:**
@@ -785,8 +784,8 @@
 - Google GDE link navigates to me.developers.google.com
 - Microsoft MVP link navigates to mvp.microsoft.com
 - GitHub Star Alumni link navigates to stars.github.com/alumni/
-- Nuxt Ambassador link navigates to nuxt.com/team
-- All links open in new tab or current tab
+- Nuxt Ambassador badge is visible but not a link
+- Linked badges open in new tab or current tab
 
 ---
 

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -99,11 +99,11 @@ test.describe('About Page', () => {
               - article:
                 - heading "Learn more about Auth0 Ambassador (opens in new tab)" [level=3]:
                   - link "Learn more about Auth0 Ambassador (opens in new tab)":
-                    - /url: https://auth0.com/ambassador-program/
+                    - /url: https://community.auth0.com/
                     - text: Auth0 Ambassador
                 - paragraph
                 - link "About Auth0 Ambassador":
-                  - /url: https://auth0.com/ambassador-program/
+                  - /url: https://community.auth0.com/
             - listitem:
               - article:
                 - heading "Learn more about Microsoft Certified (opens in new tab)" [level=3]:

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -81,11 +81,11 @@ test.describe('About Page', () => {
               - article:
                 - heading "Learn more about Nuxt Ambassador (opens in new tab)" [level=3]:
                   - link "Learn more about Nuxt Ambassador (opens in new tab)":
-                    - /url: https://nuxtjs.org/teams/
+                    - /url: https://nuxt.com/team
                     - text: Nuxt Ambassador
                 - paragraph
                 - link "About Nuxt Ambassador":
-                  - /url: https://nuxtjs.org/teams/
+                  - /url: https://nuxt.com/team
             - listitem:
               - article:
                 - heading "Learn more about Media Developer Expert (opens in new tab)" [level=3]:

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -79,13 +79,8 @@ test.describe('About Page', () => {
                   - /url: https://mvp.microsoft.com/en-us/PublicProfile/5003613?fullName=Debbie%20O%27Brien
             - listitem:
               - article:
-                - heading "Learn more about Nuxt Ambassador (opens in new tab)" [level=3]:
-                  - link "Learn more about Nuxt Ambassador (opens in new tab)":
-                    - /url: https://nuxt.com/team
-                    - text: Nuxt Ambassador
+                - heading "Nuxt Ambassador" [level=3]
                 - paragraph
-                - link "About Nuxt Ambassador":
-                  - /url: https://nuxt.com/team
             - listitem:
               - article:
                 - heading "Learn more about Media Developer Expert (opens in new tab)" [level=3]:
@@ -95,15 +90,6 @@ test.describe('About Page', () => {
                 - paragraph
                 - link "About Media Developer Expert":
                   - /url: https://cloudinary.com/mde
-            - listitem:
-              - article:
-                - heading "Learn more about Auth0 Ambassador (opens in new tab)" [level=3]:
-                  - link "Learn more about Auth0 Ambassador (opens in new tab)":
-                    - /url: https://community.auth0.com/
-                    - text: Auth0 Ambassador
-                - paragraph
-                - link "About Auth0 Ambassador":
-                  - /url: https://community.auth0.com/
             - listitem:
               - article:
                 - heading "Learn more about Microsoft Certified (opens in new tab)" [level=3]:
@@ -138,7 +124,10 @@ test.describe('About Page', () => {
   test('About page - Validates award article count and links', async ({ page }) => {
     await test.step('Count award articles', async () => {
       const articles = page.getByRole('region', { name: 'Awards & Achievements' }).getByRole('article');
-      await expect(articles).toHaveCount(9);
+      await expect(articles).toHaveCount(8);
+      await expect(page.getByRole('heading', { name: 'Nuxt Ambassador', level: 3 })).toBeVisible();
+      await expect(page.getByRole('link', { name: /Nuxt Ambassador/i })).toHaveCount(0);
+      await expect(page.getByRole('link', { name: /Auth0 Ambassador/i })).toHaveCount(0);
     });
 
     await test.step('Verify external award links', async () => {

--- a/tests/award-links.spec.ts
+++ b/tests/award-links.spec.ts
@@ -44,15 +44,8 @@ test('GitHub Star link in home page works', async ({ page }) => {
   await expect(page1).toHaveURL('https://stars.github.com/alumni/');
 });
 
-test('Nuxt Ambassador link in home page works', async ({ page }) => {
-  await page.context().route('https://nuxt.com/**', route => route.fulfill({
-    body: '<html><body><h1>Nuxt Ambassador</h1></body></html>'
-  }));
-
-  const [page1] = await Promise.all([
-    page.waitForEvent('popup'),
-    page.getByRole('link', { name: 'Nuxt Ambassador' }).click()
-  ]);
-  await expect(page1).toHaveURL('https://nuxt.com/team');
+test('Nuxt Ambassador badge is shown without a link', async ({ page }) => {
+  await expect(page.getByText('Nuxt Ambassador', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Nuxt Ambassador' })).toHaveCount(0);
 });
 

--- a/tests/award-links.spec.ts
+++ b/tests/award-links.spec.ts
@@ -45,7 +45,7 @@ test('GitHub Star link in home page works', async ({ page }) => {
 });
 
 test('Nuxt Ambassador link in home page works', async ({ page }) => {
-  await page.context().route('https://nuxtjs.org/**', route => route.fulfill({
+  await page.context().route('https://nuxt.com/**', route => route.fulfill({
     body: '<html><body><h1>Nuxt Ambassador</h1></body></html>'
   }));
 
@@ -53,6 +53,6 @@ test('Nuxt Ambassador link in home page works', async ({ page }) => {
     page.waitForEvent('popup'),
     page.getByRole('link', { name: 'Nuxt Ambassador' }).click()
   ]);
-  await expect(page1).toHaveURL('https://nuxtjs.org/teams/');
+  await expect(page1).toHaveURL('https://nuxt.com/team');
 });
 

--- a/tests/home-featured-content.spec.ts
+++ b/tests/home-featured-content.spec.ts
@@ -117,7 +117,8 @@ test.describe('Home Page Featured Content', () => {
     await expect(page.getByRole('link', { name: 'Google GDE' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Former Microsoft MVP' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'GitHub Star Alumni' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Nuxt Ambassador' })).toBeVisible();
+    await expect(page.getByText('Nuxt Ambassador', { exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Nuxt Ambassador' })).toHaveCount(0);
   });
 
   test('home page content is accessible', async ({ page }) => {

--- a/tests/speaking-page.spec.ts
+++ b/tests/speaking-page.spec.ts
@@ -20,7 +20,7 @@ test.describe('Speaking page', () => {
     )
 
     await expect(page.getByRole('heading', { name: /The Agentic Developer/ })).toBeVisible()
-    await expect(page.getByText('Infobip Shift')).toBeVisible()
+    await expect(page.getByText('Infobip Shift', { exact: true })).toBeVisible()
     await expect(page.getByRole('link', { name: 'Infobip Shift agenda' })).toHaveAttribute(
       'href',
       'https://shift.infobip.com/agenda/',

--- a/tests/speaking-page.spec.ts
+++ b/tests/speaking-page.spec.ts
@@ -14,14 +14,14 @@ test.describe('Speaking page', () => {
 
     await expect(page.getByRole('heading', { name: /Bug Report In, Pull Request Out/ })).toBeVisible()
     await expect(page.getByText('ZurichJS Conf')).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Event site' }).first()).toHaveAttribute(
+    await expect(page.getByRole('link', { name: 'ZurichJS speaker page' })).toHaveAttribute(
       'href',
       'https://conf.zurichjs.com/speakers/debbie-o-brien',
     )
 
     await expect(page.getByRole('heading', { name: /The Agentic Developer/ })).toBeVisible()
     await expect(page.getByText('Infobip Shift')).toBeVisible()
-    await expect(page.getByRole('link', { name: 'Event site' }).nth(1)).toHaveAttribute(
+    await expect(page.getByRole('link', { name: 'Infobip Shift agenda' })).toHaveAttribute(
       'href',
       'https://shift.infobip.com/agenda/',
     )

--- a/tests/verify-award-badges-display.spec.ts
+++ b/tests/verify-award-badges-display.spec.ts
@@ -17,7 +17,8 @@ test.describe('Home Page Content Display', { tag: '@agent' }, () => {
     // 4. Verify GitHub Star Alumni badge link is present
     await expect(page.getByRole('link', { name: 'GitHub Star Alumni' })).toBeVisible();
 
-    // 5. Verify Nuxt Ambassador badge link is present
-    await expect(page.getByRole('link', { name: 'Nuxt Ambassador' })).toBeVisible();
+    // 5. Verify Nuxt Ambassador badge is present without a link
+    await expect(page.getByText('Nuxt Ambassador', { exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Nuxt Ambassador' })).toHaveCount(0);
   });
 });

--- a/tests/verify-awards-and-achievements-section.spec.ts
+++ b/tests/verify-awards-and-achievements-section.spec.ts
@@ -12,9 +12,11 @@ test.describe('About Page Content', () => {
     await expect(page.getByRole('heading', { name: 'Awards & Achievements' })).toBeVisible();
     await expect(page.getByText('Recognition and certifications that reflect my journey in technology and community contribution.')).toBeVisible();
 
-    // 3. Count the number of award cards displayed (includes Nuxt Ambassador)
+    // 3. Count the number of award cards displayed (includes unlinked Nuxt Ambassador)
     const awardCards = page.locator('main article');
-    await expect(awardCards).toHaveCount(9);
+    await expect(awardCards).toHaveCount(8);
+    await expect(page.getByRole('heading', { name: 'Nuxt Ambassador', level: 3 })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Auth0 Ambassador/i })).toHaveCount(0);
 
     // Verify specific awards are displayed
     await expect(page.getByRole('heading', { name: 'Learn more about GitHub Star Alumni (opens in new tab)' })).toBeVisible();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Small hygiene fixes from the site scout Monday digest, plus Debbie’s award-link clarifications.

## Changes
1. **Video title typo** — `Playwright MCP Severs` → `Servers`
2. **Conference place typo** — `Sweeden` → `Sweden`
3. **Speaking page a11y** — unique labels “ZurichJS speaker page” / “Infobip Shift agenda” (hrefs unchanged)
4. **Awards (Debbie’s live-page check)**
   - **Auth0 Ambassador removed entirely** from About awards, About meta description, and related Playwright asserts (award count 9 → 8). Program is gone; no page that lists Debbie as Ambassador.
   - **Nuxt Ambassador kept as historical text**, but **unlinked** on About + home hero. Do not point at `nuxt.com/team` (does not name Debbie) or Nuxt 2 teams. No ambassadors directory invented.

## Tests
- Updated about/award/home Playwright specs + ARIA snapshot
- Local run of affected specs: **18 passed** (2 skipped)

Do not merge via this agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d219130-74c3-476b-9fd6-b6834f0762ac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d219130-74c3-476b-9fd6-b6834f0762ac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

