### PR TITLE
perf(home): size YouTube thumbs on featured video strip

### DIFF
--- a/components/FeaturedVideoSection.vue
+++ b/components/FeaturedVideoSection.vue
@@ -18,7 +18,7 @@ const otherVideos = computed(() => props.list.slice(1))
       <NuxtLink :to="getYouTubeUrl(mainVideo.video)" target="_blank" rel="noopener noreferrer">
         <div class="aspect-video rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
           <img
-            :src="youtubeThumbnail(mainVideo.video, 'sddefault')"
+            :src="youtubeThumbnail(mainVideo.video, 'mqdefault')"
             :srcset="youtubeThumbnailSrcSet(mainVideo.video)"
             sizes="(min-width: 1024px) 28rem, 100vw"
             :alt="mainVideo.title"

--- a/components/FeaturedVideoSection.vue
+++ b/components/FeaturedVideoSection.vue
@@ -18,10 +18,12 @@ const otherVideos = computed(() => props.list.slice(1))
       <NuxtLink :to="getYouTubeUrl(mainVideo.video)" target="_blank" rel="noopener noreferrer">
         <div class="aspect-video rounded-xl overflow-hidden border border-gray-200 dark:border-gray-700">
           <img
-            :src="youtubeThumbnail(mainVideo.video)"
+            :src="youtubeThumbnail(mainVideo.video, 'sddefault')"
+            :srcset="youtubeThumbnailSrcSet(mainVideo.video)"
+            sizes="(min-width: 1024px) 28rem, 100vw"
             :alt="mainVideo.title"
-            width="1280"
-            height="720"
+            width="640"
+            height="360"
             fetchpriority="high"
             class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
           >
@@ -45,7 +47,7 @@ const otherVideos = computed(() => props.list.slice(1))
         <NuxtLink :to="getYouTubeUrl(video.video)" target="_blank" rel="noopener noreferrer" class="flex items-start gap-4">
           <div class="flex-shrink-0">
             <img
-              :src="youtubeThumbnail(video.video)"
+              :src="youtubeThumbnail(video.video, 'mqdefault')"
               :alt="video.title"
               width="128"
               height="72"

--- a/tests/home-featured-content.spec.ts
+++ b/tests/home-featured-content.spec.ts
@@ -61,6 +61,13 @@ test.describe('Home Page Featured Content', () => {
     const imageCount = await images.count();
     expect(imageCount).toBeGreaterThan(0);
     expect(imageCount).toBeLessThanOrEqual(5);
+
+    // Card-sized thumbs must not request hqdefault (LCP / oversized-image)
+    for (let i = 0; i < imageCount; i++) {
+      const src = await images.nth(i).getAttribute('src');
+      expect(src).toMatch(/\/(mqdefault|sddefault)\.jpg$/);
+      expect(src).not.toContain('hqdefault');
+    }
   });
 
   test('recent podcasts section displays correctly', async ({ page }) => {

--- a/tests/home-featured-content.spec.ts
+++ b/tests/home-featured-content.spec.ts
@@ -64,9 +64,7 @@ test.describe('Home Page Featured Content', () => {
 
     // Card-sized thumbs must not request hqdefault (LCP / oversized-image)
     for (let i = 0; i < imageCount; i++) {
-      const src = await images.nth(i).getAttribute('src');
-      expect(src).toMatch(/\/(mqdefault|sddefault)\.jpg$/);
-      expect(src).not.toContain('hqdefault');
+      await expect(images.nth(i)).toHaveAttribute('src', /\/(mqdefault|sddefault)(\.|$)/);
     }
   });
 

--- a/utils/youtube.ts
+++ b/utils/youtube.ts
@@ -1,11 +1,26 @@
 /**
- * `hqdefault.jpg` is the only thumbnail variant YouTube generates for every upload,
- * so it is the safe choice for a poster image.
+ * YouTube thumbnail qualities used on this site.
+ * `mqdefault` is 320×180 (true 16:9). `sddefault` is 640×480.
+ * `hqdefault` (480×360) is generated for every upload, so it remains the
+ * safe default for lite-youtube posters — see youtubePosterStyle below.
  * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
  */
-export function youtubeThumbnail(videoId: string) {
+export type YoutubeThumbnailQuality = 'mqdefault' | 'sddefault' | 'hqdefault'
+
+export function youtubeThumbnail(
+  videoId: string,
+  quality: YoutubeThumbnailQuality = 'hqdefault',
+) {
   const safeId = encodeURIComponent(videoId.trim())
-  return `https://i.ytimg.com/vi/${safeId}/hqdefault.jpg`
+  return `https://i.ytimg.com/vi/${safeId}/${quality}.jpg`
+}
+
+/**
+ * Width-matched srcset for card-sized 16:9 thumbs (home featured strip).
+ * Avoids shipping `hqdefault` when the display width is well under 480px.
+ */
+export function youtubeThumbnailSrcSet(videoId: string) {
+  return `${youtubeThumbnail(videoId, 'mqdefault')} 320w, ${youtubeThumbnail(videoId, 'sddefault')} 640w`
 }
 
 /**

--- a/utils/youtube.ts
+++ b/utils/youtube.ts
@@ -5,11 +5,11 @@
  * safe default for lite-youtube posters — see youtubePosterStyle below.
  * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
  */
-export type YoutubeThumbnailQuality = 'mqdefault' | 'sddefault' | 'hqdefault'
+export type YouTubeThumbnailQuality = 'mqdefault' | 'sddefault' | 'hqdefault'
 
 export function youtubeThumbnail(
   videoId: string,
-  quality: YoutubeThumbnailQuality = 'hqdefault',
+  quality: YouTubeThumbnailQuality = 'hqdefault',
 ) {
   const safeId = encodeURIComponent(videoId.trim())
   return `https://i.ytimg.com/vi/${safeId}/${quality}.jpg`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Lighthouse flags home featured video cards for oversized images. The strip under the hero still requested `hqdefault` (480×360) for card-sized thumbs, which hurts LCP. HTML `width`/`height` from #604 did not change the asset URL.

## Scope

- `youtubeThumbnail(videoId, quality?)` accepts `mqdefault` | `sddefault` | `hqdefault` (default stays `hqdefault` for lite-youtube posters).
- `youtubeThumbnailSrcSet` builds a 320w/640w srcset for the main home card.
- `FeaturedVideoSection` uses resilient `mqdefault` as main `src`, plus mq/sd `srcset`; side list uses `mqdefault`.
- Type renamed to `YouTubeThumbnailQuality`.
- `tests/home-featured-content.spec.ts` asserts recent-video imgs via web-first `toHaveAttribute` for `mqdefault`/`sddefault`.

Out of scope: videos page embeds, redesign of the strip, CTA/copy changes.

## Tradeoffs

Poster style keeps `hqdefault` so every upload still has a reliable lite-youtube poster and we avoid the known `sddefault.webp` 404 path on `/videos`. Main card `src` is `mqdefault` so browsers without srcset never 404 on missing `sddefault`.

## Blast Radius

Home `/` featured video images only, plus the optional quality argument on the shared helper. Callers that omit quality behave as before.

## Verification

1. Baseline: home HTML had five `…/hqdefault.jpg` img srcs.
2. Post-fix: main thumb `mqdefault` src + `mqdefault`/`sddefault` srcset; side list `mqdefault`; zero `hqdefault` on `/`.
3. Playwright: `recent videos section displays correctly` passed after Copilot follow-ups.

Manual check: open `/`, Network tab filter `ytimg`, confirm card requests are `mqdefault`/`sddefault`.

Copilot threads on #617 addressed in `3941a2d` (PR left open for Debbie merge).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68ad92a2-6746-4187-8818-0475a2670e34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68ad92a2-6746-4187-8818-0475a2670e34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

