### PR TITLE
test(ci): Selective CI Phase 0 — workers 2 + @smoke tags

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,8 +36,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* CI: 2 workers (safe step; shards already parallelize). Not 4 yet. */
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? [['blob'], ['line']] : [['html', { open: 'never' }], ['line']],
   captureGitInfo: { commit: true, diff: true },

--- a/qa/README.md
+++ b/qa/README.md
@@ -3,6 +3,8 @@
 Hunt bugs on the live site → file high-confidence GitHub issues → fix with a draft PR.  
 Inspired by [An Agent That Hunts Bugs While I Sleep](https://debbie.codes/blog/an-agent-that-hunts-bugs-while-i-sleep).
 
+Selective CI Phase 0 raises Playwright CI workers to 2 and tags `@smoke` tests. Path-filter comes later. When path-filter lands, smoke remains always required.
+
 **Skills are the playbook** (work in Cursor locally).  
 **GitHub Actions + Copilot** is the scheduled adapter (optional).
 

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -5,7 +5,7 @@ test.describe('About Page', () => {
     await page.goto('/about');
   });
 
-  test('About page - Displays hero section with greeting and title', async ({ page }) => {
+  test('About page - Displays hero section with greeting and title', { tag: '@smoke' }, async ({ page }) => {
     await test.step('Verify page title and URL', async () => {
       await expect(page).toHaveTitle('About Debbie and her experience as a developer · Debbie Codes');
       await expect(page).toHaveURL(/\/about\/?$/);

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -4,7 +4,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/');
 });
 
-test('home contains name and title', async ({ page }) => {
+test('home contains name and title', { tag: '@smoke' }, async ({ page }) => {
   await expect(page.getByRole('heading', { level: 1, name: /Debbie O'Brien/i })).toBeVisible();
   await expect(page.getByText('Developer Educator focused on Playwright, testing & AI agents')).toBeVisible();
   await expect(page.getByRole('link', { name: 'Watch on YouTube' })).toBeVisible();

--- a/tests/sitemap-and-talks-redirect.spec.ts
+++ b/tests/sitemap-and-talks-redirect.spec.ts
@@ -25,7 +25,7 @@ test.describe('Sitemap and /talks redirect', () => {
     expect(body).toMatch(/https:\/\/debbie\.codes\/blog\/[a-z0-9-]+/)
   })
 
-  test('_redirects declares forced permanent /talks → /speaking', () => {
+  test('_redirects declares forced permanent /talks → /speaking', { tag: '@smoke' }, () => {
     // Endform runners execute from /tmp without the repo checkout, so
     // public/_redirects is not on disk (ENOENT). Skip the filesystem
     // assertion there; HTTP 3xx checks below still cover deploy previews.

--- a/tests/verify-desktop-navigation-menu.spec.ts
+++ b/tests/verify-desktop-navigation-menu.spec.ts
@@ -3,7 +3,7 @@
 
 import { test, expect } from '@playwright/test';
 
-test.describe('Navigation Functionality', { tag: '@agent' }, () => {
+test.describe('Navigation Functionality', { tag: ['@agent', '@smoke'] }, () => {
   test('Verify Desktop Navigation Menu', async ({ page }) => {
     // 1. Navigate to the home page (`/`)
     await page.goto('/');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Selective CI starts with speed and structure only. Raise CI workers from 1 to 2 and mark a greppable `@smoke` set so later phases can path-filter without inventing a new suite. Full suite remains the default PR gate. No hard skips yet.

## Scope

- `playwright.config.ts`: `workers: process.env.CI ? 2 : undefined` (was `1`). Comment notes 2 is the safe first step because the 4-way shard matrix already parallelizes.
- Workflows (`playwright.yml`, `preview-tests.yml`): unchanged; they do not hardcode `--workers=1`, so config stays the source of truth.
- `@smoke` on existing tests only:
  - home load: `home contains name and title` (`tests/home.spec.ts`)
  - desktop nav: `Verify Desktop Navigation Menu` (`tests/verify-desktop-navigation-menu.spec.ts`, with existing `@agent`)
  - content page: About hero (`tests/about-page.spec.ts`)
  - redirect: `_redirects` `/talks` → `/speaking` (`tests/sitemap-and-talks-redirect.spec.ts`)
- `qa/README.md`: one sentence on Phase 0 vs later path-filter (smoke stays required when path-filter lands).

**Out of scope:** path→group filtering, dry-run scripts, smoke-only CI jobs, dropping Endform / preview-tests / shards, hard skips.

## Tradeoffs

Workers stay at 2, not 4, so shard fan-out is not compounded into flaky local contention on GHA runners before we measure.

Redirect smoke uses the `_redirects` file assertion (always runs in GHA/local) rather than the HTTP 3xx test (skips without a deploy-preview base URL).

## Blast Radius

CI wall time and parallel load per shard increase modestly. Test behavior and the default CI command (`npx playwright test --shard=…`) are unchanged. Preview and Endform workflows keep their current shape.

## Verification

- `npx playwright test --grep @smoke --list` → 4 tests in 4 files (home, desktop nav, About hero, `/talks`→`/speaking` `_redirects`).
- `npx playwright test --grep @smoke` → **4 passed** locally (dev server via config `webServer`).
- `CI=true npx playwright test --grep @smoke` → **4 passed** using **2 workers**.
- Workflows still invoke the full suite; no smoke-only job.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-650e3b9d-b0d5-4a70-b68b-2f41ad7b0c0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-650e3b9d-b0d5-4a70-b68b-2f41ad7b0c0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

