### PR TITLE
Selective CI Phase 1: path→group dry-run (report only)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,9 @@ jobs:
         shardTotal: [4]
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Need merge-base history so the selective-ci dry-run can diff against the PR base.
+        fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
@@ -22,6 +25,12 @@ jobs:
       run: npm ci
     - name: Check Google Chrome
       run: google-chrome --version
+
+    # Phase 1 selective CI: report-only path→group plan. Does NOT skip tests.
+    # Run once (shard 1) so the job summary is not duplicated across the matrix.
+    - name: Selective CI plan (dry-run)
+      if: github.event_name == 'pull_request' && matrix.shardIndex == 1
+      run: node qa/scripts/selective-ci-plan.mjs --base "origin/${{ github.base_ref }}" --summary
 
     - name: Run Playwright tests
       run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}

--- a/qa/README.md
+++ b/qa/README.md
@@ -3,7 +3,36 @@
 Hunt bugs on the live site → file high-confidence GitHub issues → fix with a draft PR.  
 Inspired by [An Agent That Hunts Bugs While I Sleep](https://debbie.codes/blog/an-agent-that-hunts-bugs-while-i-sleep).
 
-Selective CI Phase 0 raises Playwright CI workers to 2 and tags `@smoke` tests. Path-filter comes later. When path-filter lands, smoke remains always required.
+## Selective CI (Playwright)
+
+| Phase | Status | What it does |
+|-------|--------|--------------|
+| **0** | Done | CI workers = 2; `@smoke` tags on home + nav + one content + one redirect |
+| **1** | Report-only (this) | Path→group mapper **prints** which tests would run; **does not skip** anything. Full suite remains the default CI command. |
+| **2** | Later | Flip `SELECTIVE_CI=1` to actually filter using the same map |
+
+### Phase 1 dry-run (local)
+
+```bash
+# Against main (same idea as CI)
+node qa/scripts/selective-ci-plan.mjs --base main
+
+# Or origin/main after fetching
+git fetch origin main
+node qa/scripts/selective-ci-plan.mjs --base origin/main
+
+# Fake a content-only PR without committing:
+node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md
+# → mode=selective, groups=blog, always grep=@smoke
+
+# Shared layout change → fail closed to full suite:
+node qa/scripts/selective-ci-plan.mjs --files layouts/default.vue
+# → mode=full
+```
+
+Map data lives in [`qa/selective-ci/path-group-map.json`](./selective-ci/path-group-map.json) so Phase 2 can reuse it. Unknown paths and shared surfaces (`components/**`, `layouts/**`, `nuxt.config.*`, CSS/assets, `composables/**`, `server/**`, `public/**`, content helpers, workflows, `tests/**`, …) always report **full suite**.
+
+CI: the Playwright workflow writes this plan to the GitHub Actions job summary on PRs (shard 1), then still runs `npx playwright test` for the full suite.
 
 **Skills are the playbook** (work in Cursor locally).  
 **GitHub Actions + Copilot** is the scheduled adapter (optional).
@@ -114,6 +143,9 @@ qa/
 ├── prompts/
 │   ├── hunt.md               ← CI hunt prompt
 │   └── fix.md                ← CI fix prompt
+├── selective-ci/
+│   └── path-group-map.json   ← path→test-group map (Phase 1 report / Phase 2 filter)
 └── scripts/
-    └── select-fix-issue.sh   ← pick one eligible issue
+    ├── select-fix-issue.sh   ← pick one eligible issue
+    └── selective-ci-plan.mjs ← dry-run planner (CI job summary + local)
 ```

--- a/qa/scripts/selective-ci-plan.mjs
+++ b/qa/scripts/selective-ci-plan.mjs
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+/**
+ * Selective CI Phase 1 — path→group dry-run (report only).
+ *
+ * Resolves which Playwright files / @smoke grep would run for changed paths,
+ * but does NOT skip tests. Full suite remains the CI default.
+ *
+ * Usage:
+ *   node qa/scripts/selective-ci-plan.mjs --base origin/main
+ *   node qa/scripts/selective-ci-plan.mjs --base main
+ *   node qa/scripts/selective-ci-plan.mjs --files content/blog/foo.md,pages/blog/index.vue
+ *   node qa/scripts/selective-ci-plan.mjs --base origin/main --summary
+ *
+ * Exit 0 always on successful planning (even when mode=full). Non-zero only on
+ * script/IO errors so CI never fails the suite because of the dry-run itself.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { readFileSync, appendFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = resolve(__dirname, '../..')
+const MAP_PATH = join(REPO_ROOT, 'qa/selective-ci/path-group-map.json')
+
+function parseArgs(argv) {
+  const out = { base: null, files: null, summary: false, help: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--help' || a === '-h') out.help = true
+    else if (a === '--summary') out.summary = true
+    else if (a === '--base') out.base = argv[++i]
+    else if (a.startsWith('--base=')) out.base = a.slice('--base='.length)
+    else if (a === '--files') out.files = argv[++i]
+    else if (a.startsWith('--files=')) out.files = a.slice('--files='.length)
+    else throw new Error(`Unknown argument: ${a}`)
+  }
+  return out
+}
+
+function printHelp() {
+  console.log(`Selective CI plan (Phase 1 dry-run)
+
+Usage:
+  node qa/scripts/selective-ci-plan.mjs --base <ref>
+  node qa/scripts/selective-ci-plan.mjs --files <path,path,...>
+  node qa/scripts/selective-ci-plan.mjs --base <ref> --summary
+
+Options:
+  --base <ref>   Git ref to diff against (e.g. origin/main, main)
+  --files <list> Comma-separated paths (skip git; for local examples)
+  --summary      Also append markdown to $GITHUB_STEP_SUMMARY when set
+  -h, --help     Show this help
+
+Phase 1 is report-only: CI still runs the full Playwright suite.
+`)
+}
+
+/** Minimal glob: * (one segment), ** (any depth), trailing /** optional */
+function globToRegExp(glob) {
+  const normalized = glob.replace(/\\/g, '/').replace(/^\.\//, '')
+  let re = '^'
+  for (let i = 0; i < normalized.length; i++) {
+    const c = normalized[i]
+    if (c === '*' && normalized[i + 1] === '*') {
+      if (normalized[i + 2] === '/') {
+        re += '(?:.*/)?'
+        i += 2
+      }
+      else {
+        re += '.*'
+        i += 1
+      }
+    }
+    else if (c === '*') {
+      re += '[^/]*'
+    }
+    else if ('.+^$()[]{}|?\\'.includes(c)) {
+      re += `\\${c}`
+    }
+    else {
+      re += c
+    }
+  }
+  re += '$'
+  return new RegExp(re)
+}
+
+function matchesGlob(path, glob) {
+  const p = path.replace(/\\/g, '/').replace(/^\.\//, '')
+  return globToRegExp(glob).test(p)
+}
+
+function loadMap() {
+  return JSON.parse(readFileSync(MAP_PATH, 'utf8'))
+}
+
+function listChangedFiles(baseRef) {
+  // Triple-dot: changes on this branch since merge-base with base.
+  const out = execFileSync(
+    'git',
+    ['diff', '--name-only', '-z', `${baseRef}...HEAD`],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  )
+  return out.split('\0').map(s => s.trim()).filter(Boolean)
+}
+
+function normalizeFiles(files) {
+  return files
+    .map(f => relative(REPO_ROOT, resolve(REPO_ROOT, f.replace(/\\/g, '/'))).replace(/\\/g, '/'))
+    .filter(Boolean)
+}
+
+/**
+ * @returns {{
+ *   mode: 'full' | 'selective',
+ *   reason: string,
+ *   changedFiles: string[],
+ *   matchedGroups: string[],
+ *   fullTriggers: { path: string, glob: string }[],
+ *   unknownPaths: string[],
+ *   tests: string[],
+ *   grep: string[],
+ *   wouldRunCommand: string,
+ * }}
+ */
+function resolvePlan(changedFiles, map) {
+  const fullTriggers = []
+  const unknownPaths = []
+  const matchedGroupNames = new Set()
+  const groupPathMatched = new Set()
+
+  const groupEntries = Object.entries(map.groups || {})
+
+  for (const file of changedFiles) {
+    let hitFull = false
+    for (const glob of map.fullSuitePathGlobs || []) {
+      if (matchesGlob(file, glob)) {
+        fullTriggers.push({ path: file, glob })
+        hitFull = true
+        break
+      }
+    }
+    if (hitFull) continue
+
+    let hitGroup = false
+    for (const [name, group] of groupEntries) {
+      for (const glob of group.paths || []) {
+        if (matchesGlob(file, glob)) {
+          matchedGroupNames.add(name)
+          groupPathMatched.add(file)
+          hitGroup = true
+          break
+        }
+      }
+    }
+    if (!hitGroup) unknownPaths.push(file)
+  }
+
+  const grep = [...(map.alwaysInclude?.grep || ['@smoke'])]
+
+  if (changedFiles.length === 0) {
+    return {
+      mode: 'full',
+      reason: 'No changed files detected against base — fail closed to full suite.',
+      changedFiles,
+      matchedGroups: [],
+      fullTriggers,
+      unknownPaths,
+      tests: [],
+      grep,
+      wouldRunCommand: 'npx playwright test   # full suite (default)',
+    }
+  }
+
+  if (fullTriggers.length > 0) {
+    const samples = fullTriggers.slice(0, 8).map(t => `${t.path} (← ${t.glob})`).join(', ')
+    return {
+      mode: 'full',
+      reason: `Fail closed: shared/infrastructure path(s) matched full-suite globs — e.g. ${samples}`,
+      changedFiles,
+      matchedGroups: [...matchedGroupNames].sort(),
+      fullTriggers,
+      unknownPaths,
+      tests: [],
+      grep,
+      wouldRunCommand: 'npx playwright test   # full suite (default)',
+    }
+  }
+
+  if (unknownPaths.length > 0) {
+    return {
+      mode: 'full',
+      reason: `Fail closed: unknown/unmapped path(s): ${unknownPaths.join(', ')}`,
+      changedFiles,
+      matchedGroups: [...matchedGroupNames].sort(),
+      fullTriggers,
+      unknownPaths,
+      tests: [],
+      grep,
+      wouldRunCommand: 'npx playwright test   # full suite (default)',
+    }
+  }
+
+  const tests = new Set()
+  for (const name of matchedGroupNames) {
+    for (const t of map.groups[name].tests || []) tests.add(t)
+  }
+  const testList = [...tests].sort()
+  const groups = [...matchedGroupNames].sort()
+
+  // Phase 2 sketch: run listed files OR anything tagged @smoke.
+  // Playwright: `npx playwright test <files...> --grep-invert` is wrong;
+  // better: run `npx playwright test --grep @smoke` union file list.
+  const wouldRunCommand = [
+    '# Phase 2 sketch only — Phase 1 does not execute this:',
+    `npx playwright test ${testList.join(' ')}`,
+    `npx playwright test --grep '${grep.join('|')}'   # always-on smoke (may overlap files above)`,
+  ].join('\n')
+
+  return {
+    mode: 'selective',
+    reason: `All changed paths mapped to group(s): ${groups.join(', ')}. @smoke always included.`,
+    changedFiles,
+    matchedGroups: groups,
+    fullTriggers,
+    unknownPaths,
+    tests: testList,
+    grep,
+    wouldRunCommand,
+  }
+}
+
+function formatHuman(plan, { base, mapPath }) {
+  const lines = []
+  lines.push('=== Selective CI plan (Phase 1 dry-run) ===')
+  lines.push('Report only — full Playwright suite still runs in CI.')
+  lines.push('')
+  if (base) lines.push(`Base ref: ${base}`)
+  lines.push(`Map: ${relative(REPO_ROOT, mapPath)}`)
+  lines.push(`Mode: ${plan.mode.toUpperCase()}`)
+  lines.push(`Reason: ${plan.reason}`)
+  lines.push('')
+  lines.push('Changed paths:')
+  if (plan.changedFiles.length === 0) lines.push('  (none)')
+  else plan.changedFiles.forEach(f => lines.push(`  - ${f}`))
+  lines.push('')
+
+  if (plan.fullTriggers.length) {
+    lines.push('Full-suite trigger matches:')
+    plan.fullTriggers.forEach(t => lines.push(`  - ${t.path}  (glob: ${t.glob})`))
+    lines.push('')
+  }
+  if (plan.unknownPaths.length) {
+    lines.push('Unknown / unmapped paths:')
+    plan.unknownPaths.forEach(f => lines.push(`  - ${f}`))
+    lines.push('')
+  }
+  if (plan.matchedGroups.length) {
+    lines.push(`Matched groups: ${plan.matchedGroups.join(', ')}`)
+    lines.push('')
+  }
+
+  lines.push('Would run (Phase 2):')
+  lines.push(`  Always grep: ${plan.grep.join(', ')}`)
+  if (plan.mode === 'full') {
+    lines.push('  Test files: (entire suite under tests/)')
+  }
+  else if (plan.tests.length) {
+    plan.tests.forEach(t => lines.push(`  - ${t}`))
+  }
+  else {
+    lines.push('  Test files: (none beyond @smoke)')
+  }
+  lines.push('')
+  lines.push('Would-run command sketch:')
+  plan.wouldRunCommand.split('\n').forEach(l => lines.push(`  ${l}`))
+  lines.push('')
+  lines.push('Phase 1: no tests skipped. CI command remains: npx playwright test')
+  return lines.join('\n')
+}
+
+function formatMarkdown(plan, { base, mapPath }) {
+  const lines = []
+  lines.push('## Selective CI plan (Phase 1 dry-run)')
+  lines.push('')
+  lines.push('_Report only — full Playwright suite still runs. Nothing is skipped._')
+  lines.push('')
+  lines.push(`| | |`)
+  lines.push(`|---|---|`)
+  lines.push(`| **Mode** | \`${plan.mode}\` |`)
+  if (base) lines.push(`| **Base** | \`${base}\` |`)
+  lines.push(`| **Map** | \`${relative(REPO_ROOT, mapPath)}\` |`)
+  lines.push(`| **Reason** | ${plan.reason.replace(/\|/g, '\\|')} |`)
+  lines.push('')
+  lines.push('### Changed paths')
+  if (!plan.changedFiles.length) lines.push('- _(none)_')
+  else plan.changedFiles.forEach(f => lines.push(`- \`${f}\``))
+  lines.push('')
+
+  if (plan.fullTriggers.length) {
+    lines.push('### Full-suite triggers')
+    plan.fullTriggers.forEach(t => lines.push(`- \`${t.path}\` ← \`${t.glob}\``))
+    lines.push('')
+  }
+  if (plan.unknownPaths.length) {
+    lines.push('### Unknown paths (fail closed)')
+    plan.unknownPaths.forEach(f => lines.push(`- \`${f}\``))
+    lines.push('')
+  }
+  if (plan.matchedGroups.length) {
+    lines.push(`### Matched groups`)
+    lines.push(plan.matchedGroups.map(g => `\`${g}\``).join(', '))
+    lines.push('')
+  }
+
+  lines.push('### Would run (Phase 2 preview)')
+  lines.push(`- Always grep: ${plan.grep.map(g => `\`${g}\``).join(', ')}`)
+  if (plan.mode === 'full') {
+    lines.push('- Test files: **full suite** (`tests/**`)')
+  }
+  else {
+    plan.tests.forEach(t => lines.push(`- \`${t}\``))
+  }
+  lines.push('')
+  lines.push('```text')
+  lines.push(plan.wouldRunCommand)
+  lines.push('```')
+  lines.push('')
+  lines.push('Phase 1 keeps: `npx playwright test` (full suite).')
+  return lines.join('\n')
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.help) {
+    printHelp()
+    process.exit(0)
+  }
+  if (!args.base && !args.files) {
+    printHelp()
+    console.error('Error: provide --base <ref> or --files <list>')
+    process.exit(1)
+  }
+
+  const map = loadMap()
+  let changedFiles
+  if (args.files) {
+    changedFiles = normalizeFiles(args.files.split(',').map(s => s.trim()).filter(Boolean))
+  }
+  else {
+    changedFiles = normalizeFiles(listChangedFiles(args.base))
+  }
+
+  const plan = resolvePlan(changedFiles, map)
+  const human = formatHuman(plan, { base: args.base, mapPath: MAP_PATH })
+  console.log(human)
+
+  if (args.summary) {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY
+    if (summaryPath) {
+      appendFileSync(summaryPath, `${formatMarkdown(plan, { base: args.base, mapPath: MAP_PATH })}\n`)
+      console.log(`Wrote plan to GITHUB_STEP_SUMMARY (${summaryPath})`)
+    }
+    else {
+      console.log('(No GITHUB_STEP_SUMMARY env — markdown summary skipped)')
+    }
+  }
+
+  // Machine-readable trailing marker for local/CI assertions
+  console.log(`SELECTIVE_CI_MODE=${plan.mode}`)
+}
+
+try {
+  main()
+}
+catch (err) {
+  console.error('selective-ci-plan failed:', err?.message || err)
+  process.exit(1)
+}

--- a/qa/selective-ci/path-group-map.json
+++ b/qa/selective-ci/path-group-map.json
@@ -1,0 +1,99 @@
+{
+  "$schema_comment": "Selective CI path→group map. Phase 1 = report-only dry-run. Phase 2 can honor SELECTIVE_CI=1 using this same file.",
+  "version": 1,
+  "alwaysInclude": {
+    "grep": ["@smoke"],
+    "description": "Always include @smoke in the would-run set (home + nav + one content + one redirect)."
+  },
+  "fullSuitePathGlobs": [
+    "components/**",
+    "layouts/**",
+    "nuxt.config.*",
+    "assets/**",
+    "composables/**",
+    "server/**",
+    "public/**",
+    "content.config.*",
+    "utils/**",
+    "plugins/**",
+    "app.vue",
+    "tailwind.config.*",
+    "package.json",
+    "package-lock.json",
+    "playwright.config.*",
+    "playwright.service.config.*",
+    "tests/**",
+    ".github/workflows/**",
+    "endform.config.*",
+    "ENDFORM.md"
+  ],
+  "groups": {
+    "home": {
+      "description": "Home page and featured/recent strips driven by pages/index*",
+      "paths": ["pages/index.vue", "pages/index.*"],
+      "tests": [
+        "tests/home.spec.ts",
+        "tests/home-featured-content.spec.ts",
+        "tests/verify-home-page-header-and-introduction.spec.ts",
+        "tests/verify-recent-blog-posts-section.spec.ts",
+        "tests/verify-recent-podcasts-section.spec.ts",
+        "tests/verify-recent-videos-section.spec.ts",
+        "tests/verify-featured-posts-section.spec.ts",
+        "tests/verify-featured-podcast-section.spec.ts",
+        "tests/award-links.spec.ts",
+        "tests/verify-award-badges-display.spec.ts"
+      ]
+    },
+    "about": {
+      "description": "About page + award specs",
+      "paths": ["pages/about*", "content/about.md"],
+      "tests": [
+        "tests/about-page.spec.ts",
+        "tests/verify-about-page-biography.spec.ts",
+        "tests/verify-awards-and-achievements-section.spec.ts",
+        "tests/award-links.spec.ts",
+        "tests/verify-award-badges-display.spec.ts"
+      ]
+    },
+    "videos": {
+      "description": "Videos listing/filters/pagination (shared home strip lives under components/** → full suite)",
+      "paths": ["pages/videos/**", "pages/videos*", "content/videos/**"],
+      "tests": [
+        "tests/video-filters.spec.ts",
+        "tests/videos-pagination.spec.ts"
+      ]
+    },
+    "blog": {
+      "description": "Blog pages and content",
+      "paths": ["pages/blog/**", "pages/blog*", "content/blog/**"],
+      "tests": [
+        "tests/blog.spec.ts",
+        "tests/blog-filters.spec.ts",
+        "tests/blog-search.spec.ts",
+        "tests/blog-tag-normalization.spec.ts",
+        "tests/blog-year-navigation.spec.ts"
+      ]
+    },
+    "podcasts": {
+      "description": "Podcasts pages and content",
+      "paths": ["pages/podcasts/**", "pages/podcasts*", "content/podcasts/**"],
+      "tests": ["tests/podcasts.spec.ts"]
+    },
+    "speaking": {
+      "description": "Speaking page and content",
+      "paths": ["pages/speaking*", "content/speaking/**"],
+      "tests": [
+        "tests/speaking-page.spec.ts",
+        "tests/sitemap-and-talks-redirect.spec.ts"
+      ]
+    },
+    "courses": {
+      "description": "Courses pages and content",
+      "paths": ["pages/courses/**", "pages/courses*", "content/courses/**"],
+      "tests": [
+        "tests/courses-current.spec.ts",
+        "tests/course-filters.spec.ts"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 Selective CI: add a path→test-group mapper that **reports** which Playwright files/`@smoke` would run for a PR’s changed files, but **does not skip any tests**. The full suite remains the CI command everywhere.

### What landed
- Map: `qa/selective-ci/path-group-map.json` (single source of truth for Phase 2)
- Planner: `qa/scripts/selective-ci-plan.mjs` (`--base`, `--files`, `--summary`)
- CI: extra step on `playwright.yml` (PR + shard 1) writes the plan to `$GITHUB_STEP_SUMMARY`, then still runs `npx playwright test`
- Docs: `qa/README.md` notes Phase 1 = report-only

### Behavior
- Always includes `@smoke` in the would-run set
- **Fail closed** → `mode=full` for unknown paths and shared surfaces (`components/**`, `layouts/**`, `nuxt.config.*`, assets/CSS, `composables/**`, `server/**`, `public/**`, content helpers/`utils/**`, workflows, `tests/**`, …)
- Coarse selective groups: home, about, videos, blog, podcasts, speaking, courses

## How to verify

```bash
# Content-only blog change → selective (smoke + blog), not full
node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md
# Expect: SELECTIVE_CI_MODE=selective, groups=blog, @smoke listed

# Shared layout → full suite
node qa/scripts/selective-ci-plan.mjs --files layouts/default.vue
# Expect: SELECTIVE_CI_MODE=full

# Against PR base (this PR touches workflows → full, which is correct)
node qa/scripts/selective-ci-plan.mjs --base origin/main
```

On this PR’s Playwright job (shard 1), open the job summary for the dry-run markdown; the following step still runs the full sharded suite.

## Out of scope (intentionally)
- No hard-skipping / smoke-only CI jobs
- No Endform or preview-tests changes
- No worker count changes
- No retagging of the Endform-skipped `_redirects` filesystem smoke test

## Test plan
- [x] Local `--files` scenarios (blog selective, layouts/components/public/workflows full, multi-group, unknown contact → full)
- [x] `--summary` writes markdown when `GITHUB_STEP_SUMMARY` is set
- [x] `--base origin/main` on this branch reports full (workflow touch)
- [ ] CI job summary appears on this PR’s Playwright workflow run

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48404f1a-38f1-4f4a-a68e-38d1fc79c3d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48404f1a-38f1-4f4a-a68e-38d1fc79c3d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

