### PR TITLE
Selective CI Phase 2: enforce path-filter on local Playwright PRs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,20 +4,67 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+
+# Phase 2 selective CI (local GHA only):
+# - pull_request: plan job maps changed paths → selective file set (or full / fail-closed)
+# - push to main: always full suite (no path filter)
+# Safety nets unchanged: preview-tests.yml + endform-tests.yml still run the full suite on PRs.
+
 jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.plan.outputs.mode }}
+      test_files: ${{ steps.plan.outputs.test_files }}
+      shard_total: ${{ steps.plan.outputs.shard_total }}
+      shards: ${{ steps.plan.outputs.shards }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need merge-base history so the planner can diff against the PR base.
+          fetch-depth: 0
+
+      - name: Ensure PR base ref is available
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Selective CI plan (enforce on PR)
+        id: plan
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "test_files=" >> "$GITHUB_OUTPUT"
+            echo "shard_total=4" >> "$GITHUB_OUTPUT"
+            echo "shards=[1,2,3,4]" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Selective CI plan (push to main)"
+              echo ""
+              echo "_Push to main — full Playwright suite (no path filter)._"
+              echo ""
+              echo "| | |"
+              echo "|---|---|"
+              echo "| **Mode** | \`full\` |"
+              echo "| **Shards** | \`4\` |"
+              echo "| **Reason** | Path-filter is PR-only; main always runs the full suite. |"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          node qa/scripts/selective-ci-plan.mjs \
+            --base "origin/${{ github.base_ref }}" \
+            --summary \
+            --enforce
+
   playwright-tests:
+    needs: plan
     timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4]
-        shardTotal: [4]
+        shardIndex: ${{ fromJson(needs.plan.outputs.shards) }}
     steps:
     - uses: actions/checkout@v4
-      with:
-        # Need merge-base history so the selective-ci dry-run can diff against the PR base.
-        fetch-depth: 0
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
@@ -26,14 +73,20 @@ jobs:
     - name: Check Google Chrome
       run: google-chrome --version
 
-    # Phase 1 selective CI: report-only path→group plan. Does NOT skip tests.
-    # Run once (shard 1) so the job summary is not duplicated across the matrix.
-    - name: Selective CI plan (dry-run)
-      if: github.event_name == 'pull_request' && matrix.shardIndex == 1
-      run: node qa/scripts/selective-ci-plan.mjs --base "origin/${{ github.base_ref }}" --summary
-
     - name: Run Playwright tests
-      run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+      env:
+        SELECTIVE_CI_MODE: ${{ needs.plan.outputs.mode }}
+        SELECTIVE_CI_TEST_FILES: ${{ needs.plan.outputs.test_files }}
+        SELECTIVE_CI_SHARD_TOTAL: ${{ needs.plan.outputs.shard_total }}
+        SHARD_INDEX: ${{ matrix.shardIndex }}
+      run: |
+        set -euo pipefail
+        if [ "$SELECTIVE_CI_MODE" = "selective" ]; then
+          # shellcheck disable=SC2086 — file list is space-separated paths from our map
+          npx playwright test $SELECTIVE_CI_TEST_FILES --shard="${SHARD_INDEX}/${SELECTIVE_CI_SHARD_TOTAL}"
+        else
+          npx playwright test --shard="${SHARD_INDEX}/${SELECTIVE_CI_SHARD_TOTAL}"
+        fi
 
     - name: Upload blob report to GitHub Actions Artifacts
       if: ${{ !cancelled() }}
@@ -42,6 +95,7 @@ jobs:
         name: blob-report-${{ matrix.shardIndex }}
         path: blob-report
         retention-days: 1
+
   merge-reports:
     # Merge reports after playwright-tests, even if some shards have failed
     if: ${{ !cancelled() }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           # Need merge-base history so the planner can diff against the PR base.
           fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
 
       - name: Ensure PR base ref is available
         if: github.event_name == 'pull_request'

--- a/qa/README.md
+++ b/qa/README.md
@@ -8,10 +8,19 @@ Inspired by [An Agent That Hunts Bugs While I Sleep](https://debbie.codes/blog/a
 | Phase | Status | What it does |
 |-------|--------|--------------|
 | **0** | Done | CI workers = 2; `@smoke` tags on home + nav + one content + one redirect |
-| **1** | Report-only (this) | Path→group mapper **prints** which tests would run; **does not skip** anything. Full suite remains the default CI command. |
-| **2** | Later | Flip `SELECTIVE_CI=1` to actually filter using the same map |
+| **1** | Done | Path→group mapper + job summary dry-run |
+| **2** | **This** | `playwright.yml` on **pull_request** runs only the planned set (`@smoke` files ∪ group specs), or full when fail-closed. Push to **main** stays full. |
 
-### Phase 1 dry-run (local)
+### What runs where
+
+| Workflow / event | Suite |
+|------------------|--------|
+| `playwright.yml` on **PR** | **Selective** when the map says so; **full** when fail-closed / unknown / shared globs |
+| `playwright.yml` on **push to main** | **Full** (no path filter) |
+| `preview-tests.yml` on PR | **Full** against Netlify preview (safety net — do not thin) |
+| `endform-tests.yml` on PR | **Full** (unchanged this phase; thinning is a later phase) |
+
+### Planner (local)
 
 ```bash
 # Against main (same idea as CI)
@@ -23,16 +32,28 @@ node qa/scripts/selective-ci-plan.mjs --base origin/main
 
 # Fake a content-only PR without committing:
 node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md
-# → mode=selective, groups=blog, always grep=@smoke
+# → mode=selective, groups=blog, @smoke files ∪ blog specs, shard_total=1
 
 # Shared layout change → fail closed to full suite:
 node qa/scripts/selective-ci-plan.mjs --files layouts/default.vue
-# → mode=full
+# → mode=full, shard_total=4
+
+# Dry-run summary only (Phase 1 behavior; no GITHUB_OUTPUT writes):
+node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md --summary
+
+# Enforce outputs (what CI uses):
+node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md --summary --enforce
 ```
 
-Map data lives in [`qa/selective-ci/path-group-map.json`](./selective-ci/path-group-map.json) so Phase 2 can reuse it. Unknown paths and shared surfaces (`components/**`, `layouts/**`, `nuxt.config.*`, CSS/assets, `composables/**`, `server/**`, `public/**`, content helpers, workflows, `tests/**`, …) always report **full suite**.
+Map: [`qa/selective-ci/path-group-map.json`](./selective-ci/path-group-map.json). Unknown paths and shared surfaces (`components/**`, `layouts/**`, `nuxt.config.*`, CSS/assets, `composables/**`, `server/**`, `public/**`, content helpers, workflows, `tests/**`, …) always → **full suite**. Selective always unions mapped group files with specs that declare `@smoke`.
 
-CI: the Playwright workflow writes this plan to the GitHub Actions job summary on PRs (shard 1), then still runs `npx playwright test` for the full suite.
+CI: `playwright.yml` runs a `plan` job that writes the plan to `$GITHUB_STEP_SUMMARY` and emits `mode` / `test_files` / `shards`. Selective PRs use **1 shard**; full uses **4**.
+
+### How to verify Phase 2
+
+1. **Blog-only PR** (e.g. only `content/blog/...`): local GHA Playwright job summary shows `mode=selective`, fewer files, 1 shard; preview + Endform still run the full suite.
+2. **Layout / shared change** (e.g. `layouts/default.vue`): local GHA shows `mode=full`, 4 shards; preview stays full.
+3. **Push to main**: local GHA always full (plan job summary says path-filter is PR-only).
 
 **Skills are the playbook** (work in Cursor locally).  
 **GitHub Actions + Copilot** is the scheduled adapter (optional).
@@ -144,8 +165,8 @@ qa/
 │   ├── hunt.md               ← CI hunt prompt
 │   └── fix.md                ← CI fix prompt
 ├── selective-ci/
-│   └── path-group-map.json   ← path→test-group map (Phase 1 report / Phase 2 filter)
+│   └── path-group-map.json   ← path→test-group map (Phase 2 enforce on playwright.yml PRs)
 └── scripts/
     ├── select-fix-issue.sh   ← pick one eligible issue
-    └── selective-ci-plan.mjs ← dry-run planner (CI job summary + local)
+    └── selective-ci-plan.mjs ← planner (--summary dry-run / --enforce for CI)
 ```

--- a/qa/README.md
+++ b/qa/README.md
@@ -47,7 +47,7 @@ node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md --summary 
 
 Map: [`qa/selective-ci/path-group-map.json`](./selective-ci/path-group-map.json). Unknown paths and shared surfaces (`components/**`, `layouts/**`, `nuxt.config.*`, CSS/assets, `composables/**`, `server/**`, `public/**`, content helpers, workflows, `tests/**`, …) always → **full suite**. Selective always unions mapped group files with specs that declare `@smoke`.
 
-CI: `playwright.yml` runs a `plan` job that writes the plan to `$GITHUB_STEP_SUMMARY` and emits `mode` / `test_files` / `shards`. Selective PRs use **1 shard**; full uses **4**.
+CI: `playwright.yml` runs a `plan` job that writes the plan to `$GITHUB_STEP_SUMMARY` and emits `mode` / `test_files` / `shard_total` / `shards`. Selective PRs use **1 shard**; full uses **4**.
 
 ### How to verify Phase 2
 

--- a/qa/scripts/selective-ci-plan.mjs
+++ b/qa/scripts/selective-ci-plan.mjs
@@ -1,35 +1,45 @@
 #!/usr/bin/env node
 /**
- * Selective CI Phase 1 — path→group dry-run (report only).
+ * Selective CI path→group planner (Phase 1 dry-run + Phase 2 enforce).
  *
- * Resolves which Playwright files / @smoke grep would run for changed paths,
- * but does NOT skip tests. Full suite remains the CI default.
+ * Resolves which Playwright files / @smoke set would run for changed paths.
  *
  * Usage:
  *   node qa/scripts/selective-ci-plan.mjs --base origin/main
  *   node qa/scripts/selective-ci-plan.mjs --base main
  *   node qa/scripts/selective-ci-plan.mjs --files content/blog/foo.md,pages/blog/index.vue
  *   node qa/scripts/selective-ci-plan.mjs --base origin/main --summary
+ *   node qa/scripts/selective-ci-plan.mjs --base origin/main --summary --enforce
  *
  * Exit 0 always on successful planning (even when mode=full). Non-zero only on
- * script/IO errors so CI never fails the suite because of the dry-run itself.
+ * script/IO errors so CI never fails the suite because of the planner itself.
+ *
+ * --enforce writes machine-readable outputs for CI:
+ *   SELECTIVE_CI_MODE, SELECTIVE_CI_TEST_FILES, SELECTIVE_CI_SHARD_TOTAL,
+ *   and (when $GITHUB_OUTPUT is set) mode / test_files / shard_total / shards.
  */
 
 import { execFileSync } from 'node:child_process'
-import { readFileSync, appendFileSync } from 'node:fs'
+import { appendFileSync, readdirSync, readFileSync } from 'node:fs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const REPO_ROOT = resolve(__dirname, '../..')
 const MAP_PATH = join(REPO_ROOT, 'qa/selective-ci/path-group-map.json')
+const TESTS_DIR = join(REPO_ROOT, 'tests')
+
+/** Full suite keeps 4 shards; selective PRs use 1 (small file sets). */
+const FULL_SHARD_TOTAL = 4
+const SELECTIVE_SHARD_TOTAL = 1
 
 function parseArgs(argv) {
-  const out = { base: null, files: null, summary: false, help: false }
+  const out = { base: null, files: null, summary: false, enforce: false, help: false }
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     if (a === '--help' || a === '-h') out.help = true
     else if (a === '--summary') out.summary = true
+    else if (a === '--enforce') out.enforce = true
     else if (a === '--base') out.base = argv[++i]
     else if (a.startsWith('--base=')) out.base = a.slice('--base='.length)
     else if (a === '--files') out.files = argv[++i]
@@ -40,20 +50,24 @@ function parseArgs(argv) {
 }
 
 function printHelp() {
-  console.log(`Selective CI plan (Phase 1 dry-run)
+  console.log(`Selective CI plan (Phase 1 dry-run / Phase 2 enforce)
 
 Usage:
   node qa/scripts/selective-ci-plan.mjs --base <ref>
   node qa/scripts/selective-ci-plan.mjs --files <path,path,...>
   node qa/scripts/selective-ci-plan.mjs --base <ref> --summary
+  node qa/scripts/selective-ci-plan.mjs --base <ref> --summary --enforce
 
 Options:
-  --base <ref>   Git ref to diff against (e.g. origin/main, main)
+  --base <ref>   Git ref to diff against (e.g. origin/main, main, or a SHA)
   --files <list> Comma-separated paths (skip git; for local examples)
   --summary      Also append markdown to $GITHUB_STEP_SUMMARY when set
+  --enforce      Write machine-readable outputs for CI (GITHUB_OUTPUT + env lines).
+                 Without --enforce, behavior stays Phase 1 report-only.
   -h, --help     Show this help
 
-Phase 1 is report-only: CI still runs the full Playwright suite.
+Fail closed → mode=full for unknown paths and shared/fullSuitePathGlobs.
+Selective mode always unions mapped group test files with @smoke-bearing specs.
 `)
 }
 
@@ -112,6 +126,26 @@ function normalizeFiles(files) {
     .filter(Boolean)
 }
 
+/** Spec files under tests/ that declare a @smoke tag (Phase 0 always-include). */
+function findSmokeTestFiles() {
+  let entries
+  try {
+    entries = readdirSync(TESTS_DIR)
+  }
+  catch {
+    return []
+  }
+  const smokeRe = /tag:\s*(?:\[[^\]]*['"]@smoke['"]|['"]@smoke['"])/
+  return entries
+    .filter(name => /\.spec\.(ts|js|mjs|cjs)$/.test(name))
+    .filter((name) => {
+      const body = readFileSync(join(TESTS_DIR, name), 'utf8')
+      return smokeRe.test(body)
+    })
+    .map(name => `tests/${name}`)
+    .sort()
+}
+
 /**
  * @returns {{
  *   mode: 'full' | 'selective',
@@ -121,17 +155,39 @@ function normalizeFiles(files) {
  *   fullTriggers: { path: string, glob: string }[],
  *   unknownPaths: string[],
  *   tests: string[],
+ *   smokeFiles: string[],
+ *   runFiles: string[],
  *   grep: string[],
- *   wouldRunCommand: string,
+ *   shardTotal: number,
+ *   shards: number[],
+ *   playwrightCommand: string,
  * }}
  */
 function resolvePlan(changedFiles, map) {
   const fullTriggers = []
   const unknownPaths = []
   const matchedGroupNames = new Set()
-  const groupPathMatched = new Set()
 
   const groupEntries = Object.entries(map.groups || {})
+  const smokeFiles = findSmokeTestFiles()
+  const grep = [...(map.alwaysInclude?.grep || ['@smoke'])]
+
+  const fullResult = (reason, extra = {}) => ({
+    mode: 'full',
+    reason,
+    changedFiles,
+    matchedGroups: [...matchedGroupNames].sort(),
+    fullTriggers,
+    unknownPaths,
+    tests: [],
+    smokeFiles,
+    runFiles: [],
+    grep,
+    shardTotal: FULL_SHARD_TOTAL,
+    shards: Array.from({ length: FULL_SHARD_TOTAL }, (_, i) => i + 1),
+    playwrightCommand: 'npx playwright test',
+    ...extra,
+  })
 
   for (const file of changedFiles) {
     let hitFull = false
@@ -149,7 +205,6 @@ function resolvePlan(changedFiles, map) {
       for (const glob of group.paths || []) {
         if (matchesGlob(file, glob)) {
           matchedGroupNames.add(name)
-          groupPathMatched.add(file)
           hitGroup = true
           break
         }
@@ -158,49 +213,17 @@ function resolvePlan(changedFiles, map) {
     if (!hitGroup) unknownPaths.push(file)
   }
 
-  const grep = [...(map.alwaysInclude?.grep || ['@smoke'])]
-
   if (changedFiles.length === 0) {
-    return {
-      mode: 'full',
-      reason: 'No changed files detected against base — fail closed to full suite.',
-      changedFiles,
-      matchedGroups: [],
-      fullTriggers,
-      unknownPaths,
-      tests: [],
-      grep,
-      wouldRunCommand: 'npx playwright test   # full suite (default)',
-    }
+    return fullResult('No changed files detected against base — fail closed to full suite.')
   }
 
   if (fullTriggers.length > 0) {
     const samples = fullTriggers.slice(0, 8).map(t => `${t.path} (← ${t.glob})`).join(', ')
-    return {
-      mode: 'full',
-      reason: `Fail closed: shared/infrastructure path(s) matched full-suite globs — e.g. ${samples}`,
-      changedFiles,
-      matchedGroups: [...matchedGroupNames].sort(),
-      fullTriggers,
-      unknownPaths,
-      tests: [],
-      grep,
-      wouldRunCommand: 'npx playwright test   # full suite (default)',
-    }
+    return fullResult(`Fail closed: shared/infrastructure path(s) matched full-suite globs — e.g. ${samples}`)
   }
 
   if (unknownPaths.length > 0) {
-    return {
-      mode: 'full',
-      reason: `Fail closed: unknown/unmapped path(s): ${unknownPaths.join(', ')}`,
-      changedFiles,
-      matchedGroups: [...matchedGroupNames].sort(),
-      fullTriggers,
-      unknownPaths,
-      tests: [],
-      grep,
-      wouldRunCommand: 'npx playwright test   # full suite (default)',
-    }
+    return fullResult(`Fail closed: unknown/unmapped path(s): ${unknownPaths.join(', ')}`)
   }
 
   const tests = new Set()
@@ -210,37 +233,45 @@ function resolvePlan(changedFiles, map) {
   const testList = [...tests].sort()
   const groups = [...matchedGroupNames].sort()
 
-  // Phase 2 sketch: run listed files OR anything tagged @smoke.
-  // Playwright: `npx playwright test <files...> --grep-invert` is wrong;
-  // better: run `npx playwright test --grep @smoke` union file list.
-  const wouldRunCommand = [
-    '# Phase 2 sketch only — Phase 1 does not execute this:',
-    `npx playwright test ${testList.join(' ')}`,
-    `npx playwright test --grep '${grep.join('|')}'   # always-on smoke (may overlap files above)`,
-  ].join('\n')
+  // Union group files with @smoke-bearing specs so one Playwright invocation
+  // covers mapped groups + always-on smoke (avoids --grep filtering group tests).
+  const runFiles = [...new Set([...testList, ...smokeFiles])].sort()
+  const shards = Array.from({ length: SELECTIVE_SHARD_TOTAL }, (_, i) => i + 1)
+  const playwrightCommand = `npx playwright test ${runFiles.join(' ')}`
 
   return {
     mode: 'selective',
-    reason: `All changed paths mapped to group(s): ${groups.join(', ')}. @smoke always included.`,
+    reason: `All changed paths mapped to group(s): ${groups.join(', ')}. @smoke files always included.`,
     changedFiles,
     matchedGroups: groups,
     fullTriggers,
     unknownPaths,
     tests: testList,
+    smokeFiles,
+    runFiles,
     grep,
-    wouldRunCommand,
+    shardTotal: SELECTIVE_SHARD_TOTAL,
+    shards,
+    playwrightCommand,
   }
 }
 
-function formatHuman(plan, { base, mapPath }) {
+function formatHuman(plan, { base, mapPath, enforce }) {
   const lines = []
-  lines.push('=== Selective CI plan (Phase 1 dry-run) ===')
-  lines.push('Report only — full Playwright suite still runs in CI.')
+  if (enforce) {
+    lines.push('=== Selective CI plan (Phase 2 enforce) ===')
+    lines.push('Local GHA Playwright will run this plan on pull_request.')
+  }
+  else {
+    lines.push('=== Selective CI plan (Phase 1 dry-run) ===')
+    lines.push('Report only — pass --enforce for CI machine outputs.')
+  }
   lines.push('')
   if (base) lines.push(`Base ref: ${base}`)
   lines.push(`Map: ${relative(REPO_ROOT, mapPath)}`)
   lines.push(`Mode: ${plan.mode.toUpperCase()}`)
   lines.push(`Reason: ${plan.reason}`)
+  lines.push(`Shards: ${plan.shardTotal} (${plan.shards.join(', ')})`)
   lines.push('')
   lines.push('Changed paths:')
   if (plan.changedFiles.length === 0) lines.push('  (none)')
@@ -262,36 +293,43 @@ function formatHuman(plan, { base, mapPath }) {
     lines.push('')
   }
 
-  lines.push('Would run (Phase 2):')
-  lines.push(`  Always grep: ${plan.grep.join(', ')}`)
+  lines.push('Will run:')
+  lines.push(`  Always grep tags: ${plan.grep.join(', ')}`)
+  lines.push(`  Smoke files: ${plan.smokeFiles.length ? plan.smokeFiles.join(', ') : '(none found)'}`)
   if (plan.mode === 'full') {
     lines.push('  Test files: (entire suite under tests/)')
   }
-  else if (plan.tests.length) {
-    plan.tests.forEach(t => lines.push(`  - ${t}`))
+  else if (plan.runFiles.length) {
+    plan.runFiles.forEach(t => lines.push(`  - ${t}`))
   }
   else {
-    lines.push('  Test files: (none beyond @smoke)')
+    lines.push('  Test files: (none)')
   }
   lines.push('')
-  lines.push('Would-run command sketch:')
-  plan.wouldRunCommand.split('\n').forEach(l => lines.push(`  ${l}`))
-  lines.push('')
-  lines.push('Phase 1: no tests skipped. CI command remains: npx playwright test')
+  lines.push('Playwright command:')
+  lines.push(`  ${plan.playwrightCommand}${plan.mode === 'full' ? '' : ` --shard=1/${plan.shardTotal}`}`)
   return lines.join('\n')
 }
 
-function formatMarkdown(plan, { base, mapPath }) {
+function formatMarkdown(plan, { base, mapPath, enforce }) {
   const lines = []
-  lines.push('## Selective CI plan (Phase 1 dry-run)')
+  lines.push(enforce
+    ? '## Selective CI plan (Phase 2 — enforced on local GHA)'
+    : '## Selective CI plan (Phase 1 dry-run)')
   lines.push('')
-  lines.push('_Report only — full Playwright suite still runs. Nothing is skipped._')
+  if (enforce) {
+    lines.push('_`playwright.yml` on this PR runs only the planned set (or full when fail-closed). `preview-tests.yml` stays full._')
+  }
+  else {
+    lines.push('_Report only — pass `--enforce` for CI outputs. Dry-run does not skip tests._')
+  }
   lines.push('')
   lines.push(`| | |`)
   lines.push(`|---|---|`)
   lines.push(`| **Mode** | \`${plan.mode}\` |`)
   if (base) lines.push(`| **Base** | \`${base}\` |`)
   lines.push(`| **Map** | \`${relative(REPO_ROOT, mapPath)}\` |`)
+  lines.push(`| **Shards** | \`${plan.shardTotal}\` |`)
   lines.push(`| **Reason** | ${plan.reason.replace(/\|/g, '\\|')} |`)
   lines.push('')
   lines.push('### Changed paths')
@@ -315,21 +353,43 @@ function formatMarkdown(plan, { base, mapPath }) {
     lines.push('')
   }
 
-  lines.push('### Would run (Phase 2 preview)')
+  lines.push('### Run set')
   lines.push(`- Always grep: ${plan.grep.map(g => `\`${g}\``).join(', ')}`)
+  lines.push(`- Smoke files: ${plan.smokeFiles.map(f => `\`${f}\``).join(', ') || '_none_'}`)
   if (plan.mode === 'full') {
     lines.push('- Test files: **full suite** (`tests/**`)')
   }
   else {
-    plan.tests.forEach(t => lines.push(`- \`${t}\``))
+    plan.runFiles.forEach(t => lines.push(`- \`${t}\``))
   }
   lines.push('')
   lines.push('```text')
-  lines.push(plan.wouldRunCommand)
+  lines.push(plan.playwrightCommand)
   lines.push('```')
-  lines.push('')
-  lines.push('Phase 1 keeps: `npx playwright test` (full suite).')
   return lines.join('\n')
+}
+
+function appendGithubOutput(plan) {
+  const outPath = process.env.GITHUB_OUTPUT
+  if (!outPath) {
+    console.log('(No GITHUB_OUTPUT env — skipping Actions outputs)')
+    return
+  }
+  const lines = [
+    `mode=${plan.mode}`,
+    `test_files=${plan.mode === 'selective' ? plan.runFiles.join(' ') : ''}`,
+    `shard_total=${plan.shardTotal}`,
+    `shards=${JSON.stringify(plan.shards)}`,
+  ]
+  appendFileSync(outPath, `${lines.join('\n')}\n`)
+  console.log(`Wrote plan outputs to GITHUB_OUTPUT (${outPath})`)
+}
+
+function printMachineReadable(plan) {
+  console.log(`SELECTIVE_CI_MODE=${plan.mode}`)
+  console.log(`SELECTIVE_CI_TEST_FILES=${plan.mode === 'selective' ? plan.runFiles.join(' ') : ''}`)
+  console.log(`SELECTIVE_CI_SHARD_TOTAL=${plan.shardTotal}`)
+  console.log(`SELECTIVE_CI_SHARDS=${JSON.stringify(plan.shards)}`)
 }
 
 function main() {
@@ -354,13 +414,13 @@ function main() {
   }
 
   const plan = resolvePlan(changedFiles, map)
-  const human = formatHuman(plan, { base: args.base, mapPath: MAP_PATH })
-  console.log(human)
+  const meta = { base: args.base, mapPath: MAP_PATH, enforce: args.enforce }
+  console.log(formatHuman(plan, meta))
 
   if (args.summary) {
     const summaryPath = process.env.GITHUB_STEP_SUMMARY
     if (summaryPath) {
-      appendFileSync(summaryPath, `${formatMarkdown(plan, { base: args.base, mapPath: MAP_PATH })}\n`)
+      appendFileSync(summaryPath, `${formatMarkdown(plan, meta)}\n`)
       console.log(`Wrote plan to GITHUB_STEP_SUMMARY (${summaryPath})`)
     }
     else {
@@ -368,8 +428,11 @@ function main() {
     }
   }
 
-  // Machine-readable trailing marker for local/CI assertions
-  console.log(`SELECTIVE_CI_MODE=${plan.mode}`)
+  printMachineReadable(plan)
+
+  if (args.enforce) {
+    appendGithubOutput(plan)
+  }
 }
 
 try {

--- a/qa/selective-ci/path-group-map.json
+++ b/qa/selective-ci/path-group-map.json
@@ -1,5 +1,5 @@
 {
-  "$schema_comment": "Selective CI path→group map. Phase 1 = report-only dry-run. Phase 2 can honor SELECTIVE_CI=1 using this same file.",
+  "$schema_comment": "Selective CI path→group map. Phase 1 dry-run + Phase 2 enforce (playwright.yml on PR). preview-tests.yml / endform-tests.yml / main push stay full.",
   "version": 1,
   "alwaysInclude": {
     "grep": ["@smoke"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 Selective CI: **`playwright.yml` on `pull_request` now enforces** the Phase 1 path→group plan. Local GHA runs only mapped group specs ∪ `@smoke` files (1 shard), or the full 4-shard suite when fail-closed. **Push to main stays full.** Preview + Endform safety nets are unchanged (still full on every PR).

### What changed
- Planner (`qa/scripts/selective-ci-plan.mjs`): `--enforce` writes `mode` / `test_files` / `shard_total` / `shards` to `$GITHUB_OUTPUT`; machine-readable `SELECTIVE_CI_*` lines always printed; `--summary` dry-run (no output writes) still available
- `playwright.yml`: new `plan` job → dynamic shard matrix → selective or full Playwright command; job summary still shows the plan
- Docs: `qa/README.md` Phase 2 table + verify steps
- **Not touched:** `preview-tests.yml`, `endform-tests.yml`

### Behavior
| Event / workflow | Suite |
|---|---|
| `playwright.yml` PR (mapped content, e.g. blog-only) | Selective (smoke ∪ group files), **1 shard** |
| `playwright.yml` PR (layouts/components/unknown/…) | Full, **4 shards** (fail closed) |
| `playwright.yml` push to main | Full, **4 shards** (no path filter) |
| `preview-tests.yml` / `endform-tests.yml` | Full (unchanged) |

### Local verification

```bash
node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md
# SELECTIVE_CI_MODE=selective, SHARD_TOTAL=1, blog ∪ @smoke files
# playwright --list → 33 tests in 9 files

node qa/scripts/selective-ci-plan.mjs --files layouts/default.vue
# SELECTIVE_CI_MODE=full, SHARD_TOTAL=4

# Dry-run (no GITHUB_OUTPUT):
node qa/scripts/selective-ci-plan.mjs --files content/blog/example.md --summary
```

Full suite baseline: **113 tests in 36 files**.

**Note:** This PR touches `.github/workflows/**` → fail-closed **full** on its own Playwright job (expected). Preview stays full.

### Out of scope
- Removing Endform from every PR
- Making preview-tests selective
- Path-filter on main pushes

### Test plan
- [x] Blog-only → selective + smoke files + 1 shard
- [x] Layout / unknown → full + 4 shards
- [x] `--enforce` writes GITHUB_OUTPUT; dry-run does not
- [x] `playwright --list` selective (33) vs full (113)
- [x] preview-tests.yml + endform-tests.yml unchanged
- [ ] CI: plan job summary on this PR; playwright runs full (workflow path); preview still full

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ca1ae76-d6dc-4d0f-97e5-46215e06a563?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ca1ae76-d6dc-4d0f-97e5-46215e06a563&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

