### PR TITLE
fix: single Close menu control on mobile drawer

### DIFF
--- a/components/TheTopBar.vue
+++ b/components/TheTopBar.vue
@@ -39,24 +39,21 @@ watch(() => route.fullPath, () => {
             <TopBarSocial />
           </div>
 
+          <!-- Hide the header toggle while open so only the overlay ✕ is
+               exposed as “Close menu” (avoids duplicate a11y dismiss controls). -->
           <button
+            v-show="!isOpen"
             class="block lg:hidden"
-            :aria-label="isOpen ? 'Close menu' : 'Open menu'"
+            aria-label="Open menu"
             :aria-expanded="isOpen"
             type="button"
             @click="toggle"
           >
-            <ul v-if="!isOpen" class="hamburger text-white">
+            <ul class="hamburger text-white">
               <li class="bg-white" />
               <li class="bg-white" />
               <li class="bg-white" />
             </ul>
-            <span
-              v-else
-              class="text-white text-2xl"
-            >
-              X
-            </span>
           </button>
         </div>
       </div>

--- a/tests/mobile-navigation.spec.ts
+++ b/tests/mobile-navigation.spec.ts
@@ -23,8 +23,8 @@ test.describe('Mobile Navigation', () => {
     await test.step('Open menu and verify it actually opened', async () => {
       // The hamburger handler is attached on hydration; a click fired before
       // that no-ops silently. Retry until the overlay close control appears.
-      // (Hamburger also switches to "Close menu" when open, so scope to the ✕.)
-      const overlayClose = page.getByRole('button', { name: 'Close menu' }).filter({ hasText: '✕' });
+      // While open, only the overlay ✕ is labeled “Close menu” (header toggle is hidden).
+      const overlayClose = page.getByRole('button', { name: 'Close menu' });
       await expect(async () => {
         await hamburgerButton.click();
         await expect(overlayClose).toBeVisible({ timeout: 2000 });
@@ -32,10 +32,29 @@ test.describe('Mobile Navigation', () => {
     });
 
     await test.step('Close menu using the close button', async () => {
-      const closeButton = page.getByRole('button', { name: 'Close menu' }).filter({ hasText: '✕' });
+      const closeButton = page.getByRole('button', { name: 'Close menu' });
       await closeButton.click();
       await expect(page.getByRole('navigation')).not.toBeVisible();
       await expect(hamburgerButton).toHaveAccessibleName('Open menu');
+    });
+  });
+
+  test('Mobile Navigation - Only one Close menu control while open', async ({ page }) => {
+    const hamburgerButton = getHamburgerButton(page);
+    const closeButtons = page.getByRole('button', { name: 'Close menu' });
+
+    await test.step('Open menu', async () => {
+      await expect(async () => {
+        await hamburgerButton.click();
+        await expect(closeButtons).toBeVisible({ timeout: 2000 });
+      }).toPass({ timeout: 15000 });
+    });
+
+    await test.step('Exactly one Close menu button in the a11y tree', async () => {
+      await expect(closeButtons).toHaveCount(1);
+      await expect(closeButtons).toHaveText('✕');
+      // Header open toggle is hidden while the drawer is open
+      await expect(page.getByRole('button', { name: 'Open menu' })).toHaveCount(0);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes duplicate mobile “Close menu” buttons (header toggle + overlay ✕) so screen-reader users get one dismiss control.

Elevated for ZurichJS “Bug Report In, Pull Request Out” demo prep (fingerprint `prod|/|mobile-duplicate-close-menu`). Honesty gates correctly mark this as `severity:minor`; Debbie elevated manually for the talk loop.

## Repro (before any code change)

1. Open https://debbie.codes/ at mobile viewport (390×844).
2. Tap **Open menu**.
3. Query `button[aria-label="Close menu"]` → **two** buttons (overlay ✕ + header `X`).

playwright-cli on production confirmed both controls in the a11y tree.

## Fix

In `components/TheTopBar.vue`, hide the header hamburger while the drawer is open (`v-show="!isOpen"`). The teleported overlay ✕ remains the single “Close menu” control (header sits under the full-screen overlay anyway).

## Verification

- **Before (prod):** `closeCount: 2` (✕ + header X)
- **After (local):** `closeCount: 1`, `openCount: 0` while drawer open; closing restores **Open menu**
- Regression: `tests/mobile-navigation.spec.ts` — “Only one Close menu control while open”
- `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:8000 npx playwright test tests/mobile-navigation.spec.ts --project=chromium -g "Only one Close menu|Hamburger menu button|Menu closes when navigation"` → **3 passed**

![Before: mobile menu open on production](https://cursor.com/artifacts/c/art-e0d4ed24-9cfa-4340-a785-44d343c472fa)
![After: single overlay Close menu locally](https://cursor.com/artifacts/c/art-ecaefc7b-a0c0-4f78-8f62-835b3ee30b63)

Closes #622

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cc4cd52-004b-4281-9cee-9c387d65accd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cc4cd52-004b-4281-9cee-9c387d65accd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

