### PR TITLE
Fix: CoachBot YouTube id → WKXZuPD7X2s

### DIFF
--- a/content/blog/i-created-an-ai-fitness-coach-with-grok-bot.md
+++ b/content/blog/i-created-an-ai-fitness-coach-with-grok-bot.md
@@ -6,7 +6,7 @@ tags: [ai, agents]
 published: true
 ---
 
-::youtube{id="L4SHDtetjwc"}
+::youtube{id="WKXZuPD7X2s"}
 ::
 
 It's totally insane. You have to see it to believe it.

--- a/content/videos/i-created-an-ai-fitness-coach-with-grok-bot.md
+++ b/content/videos/i-created-an-ai-fitness-coach-with-grok-bot.md
@@ -2,8 +2,8 @@
 title: "I Created an AI Fitness Coach with Grok Bot"
 date: 2026-09-08
 description: "I created a Grok Bot coach for gym, nutrition, and accountability after having twins. It sets goals with real constraints, builds workouts from photos of my home gym, tracks protein from food packaging, critiques workout videos, and adds follow-along videos to my YouTube playlist."
-video: L4SHDtetjwc
+video: WKXZuPD7X2s
 tags: [ai]
 host: Debbie O'Brien
-image: https://img.youtube.com/vi/L4SHDtetjwc/sddefault.jpg
+image: https://img.youtube.com/vi/WKXZuPD7X2s/sddefault.jpg
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update CoachBot fitness video frontmatter to YouTube id `WKXZuPD7X2s` (video field + thumbnail image URL).
- Update the matching blog MDC embed to `::youtube{id="WKXZuPD7X2s"}` with closing `::` on its own line.
- Content-only change; spoken-voice blog body unchanged.

## Test plan
- [ ] Confirm both files contain `WKXZuPD7X2s` and no `L4SHDtetjwc`.
- [ ] CI / deploy preview acceptable (Debbie/CoS pipeline yes for this id).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb5aaa61-5d73-4f68-920b-b1fd380871de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb5aaa61-5d73-4f68-920b-b1fd380871de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

