### PR TITLE
Fix: CoachBot blog lite-youtube embed

### DIFF
--- a/content/blog/i-created-an-ai-fitness-coach-with-grok-bot.md
+++ b/content/blog/i-created-an-ai-fitness-coach-with-grok-bot.md
@@ -6,10 +6,12 @@ tags: [ai, agents]
 published: true
 ---
 
-::youtube{id="WKXZuPD7X2s"}
-::
-
 Hey all. Today I wanted to show you what I'm doing with Grok Bot, which is CoachBot. Yes, I created a bot that's going to be my coach for gym and nutrition and all that kind of stuff.
+
+<lite-youtube
+        videoid="WKXZuPD7X2s"
+        playlabel="I Created an AI Fitness Coach with Grok Bot">
+</lite-youtube>
 
 Since having twins, my body has not been how it should be. It's really hard to get it back. The boys are almost three and I'm like, okay, come on. This is not okay.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the non-rendering `::youtube` MDC block on the CoachBot blog with `<lite-youtube>` (same pattern as the gluten-free beer post).
- Place the embed after the opening "Hey all..." paragraph.
- Video id: `WKXZuPD7X2s`.

## Test plan
- [x] Confirm file has `<lite-youtube videoid="WKXZuPD7X2s">` and no `::youtube` block.
- [x] Confirm placement matches beer post (first paragraph → blank line → lite-youtube → rest).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8f653db-a39c-4330-bda9-1789c936b0ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8f653db-a39c-4330-bda9-1789c936b0ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

