### PR TITLE
fix: contain homepage hero horizontal overflow

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -91,7 +91,8 @@ useHead({
 </script>
 
 <template>
-  <div>
+  <!-- Clip 100vw full-bleed overshoot (scrollbar gutter) without changing hero layout -->
+  <div class="overflow-x-clip">
     <a
       href="#main-content"
       class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-white focus:rounded-md"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Homepage full-bleed hero (`CreativeHero` / `hero-spotlight`) uses `w-screen` (`100vw`) with the classic `-ml-[50vw]` breakout. On browsers with classic scrollbars, `100vw` includes the scrollbar gutter, so the hero is ~8px wider than the layout viewport and `/` gets a horizontal scrollbar (e.g. scrollWidth 1272 vs clientWidth 1264 at a 1280-wide window).

## Before
- Headed Chromium, viewport 1280×800: `clientWidth` 1264, `scrollWidth` 1272, horizontal overflow δ≈8
- Hero measured ~1280px wide (`100vw`), extending past the visible content edge

![Before: horizontal scrollbar on homepage](https://cursor.com/artifacts/c/art-a4f3c0cc-4419-4fc4-8255-1e359974f634)

## Fix
Smallest containment change in `app.vue`: add `overflow-x-clip` on the app shell root so the vw overshoot is clipped without redesigning the hero or changing `CreativeHero` classes. Full-bleed edge-to-edge look is preserved inside the layout viewport.

Does not touch `/resources`. No new Playwright suite (no existing home overflow assert to extend).

## After / verification
Headed Chromium, no horizontal overflow:
- 1024×800: scrollWidth === clientWidth
- 1280×800: scrollWidth === clientWidth
- 1440×800: scrollWidth === clientWidth

Manual browser check: no horizontal scrollbar at ~1280 and ~1100; hero still full-bleed. CI green.

![After: full-bleed hero, no horizontal scrollbar at 1280](https://cursor.com/artifacts/c/art-c5edd64f-d78f-47e9-a3f8-6026946b0410)
![After: footer area with no horizontal scrollbar](https://cursor.com/artifacts/c/art-28093529-09d7-4bba-9bde-d176edda7cde)
<a href="https://cursor.com/agents/bc-c51dbee5-5c6a-48d7-8f95-1de03d37dd8a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_no_hscroll_demo_compact.mp4"><img src="https://cursor.com/artifacts/c/art-dee0fb82-365b-4279-a7c0-464b1363cf96" alt="homepage_no_hscroll_demo_compact.mp4" /></a>

## Test plan
- [x] Reproduce overflow in headed browser at ~1280
- [x] Confirm no overflow after fix at 1024 / 1280 / 1440
- [x] Manual UI check: no h-scrollbar, hero still full-bleed
- [x] CI green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c51dbee5-5c6a-48d7-8f95-1de03d37dd8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c51dbee5-5c6a-48d7-8f95-1de03d37dd8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

