### PR TITLE
Add slide decks GitHub link on Speaking page

### DIFF
--- a/pages/speaking.vue
+++ b/pages/speaking.vue
@@ -74,7 +74,14 @@ useHead({
       <NuxtLink to="/videos/tags/conference-talk" class="text-primary hover:underline">
         conference videos
       </NuxtLink>
-      page. For anything else,
+      page;
+      <a
+        href="https://github.com/debs-obrien/decks"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-primary hover:underline"
+      >slide decks on GitHub</a>.
+      For anything else,
       <a href="mailto:dobriendev@gmail.com" class="text-primary hover:underline">email me</a>.
     </p>
   </main>

--- a/pages/speaking.vue
+++ b/pages/speaking.vue
@@ -74,7 +74,7 @@ useHead({
       <NuxtLink to="/videos/tags/conference-talk" class="text-primary hover:underline">
         conference videos
       </NuxtLink>
-      page;
+      page; you can find my
       <a
         href="https://github.com/debs-obrien/decks"
         target="_blank"

--- a/tests/speaking-page.spec.ts
+++ b/tests/speaking-page.spec.ts
@@ -27,5 +27,11 @@ test.describe('Speaking page', () => {
     )
 
     await expect(page.getByRole('link', { name: /invite me/i })).toHaveCount(0)
+
+    const decksLink = page.getByRole('link', { name: 'slide decks on GitHub' })
+    await expect(decksLink).toBeVisible()
+    await expect(decksLink).toHaveAttribute('href', 'https://github.com/debs-obrien/decks')
+    await expect(decksLink).toHaveAttribute('target', '_blank')
+    await expect(decksLink).toHaveAttribute('rel', 'noopener noreferrer')
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a clear external link to https://github.com/debs-obrien/decks in the Speaking page closing paragraph (`pages/speaking.vue`), with accessible text “slide decks on GitHub”, `target="_blank"`, and `rel="noopener noreferrer"`.
- Closing copy grammar fixed per Copilot review: “Past talks live on the conference videos page; you can find my slide decks on GitHub. For anything else, email me.”
- Extends `tests/speaking-page.spec.ts` to assert the link’s visibility, href, target, and rel.
- Leaves the existing `/talks/devsum-2026` redirect and top nav unchanged.

## Test plan
- [x] `npx playwright test tests/speaking-page.spec.ts` — passed (before and after grammar fix)
- [x] Manual: `/speaking` closing copy includes conference videos + slide decks on GitHub + email
- [x] Manual: decks link opens in a new tab to https://github.com/debs-obrien/decks
- [x] Addressed Copilot review on incomplete semicolon clause

### Evidence
![Speaking page closing paragraph with slide decks link](https://cursor.com/artifacts/c/art-08970950-184c-441a-a9b9-a6e2de0265b1)
<a href="https://cursor.com/agents/bc-19ef053c-102f-442a-abac-1fddff09956a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspeaking_decks_link_opens_github.mp4"><img src="https://cursor.com/artifacts/c/art-a86afe65-18db-4788-b8c8-e4f453740018" alt="speaking_decks_link_opens_github.mp4" /></a>
![GitHub decks repo opened from Speaking link](https://cursor.com/artifacts/c/art-35c954f8-340f-4880-8d1d-dff83b7d835a)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19ef053c-102f-442a-abac-1fddff09956a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19ef053c-102f-442a-abac-1fddff09956a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

